### PR TITLE
chore: docker-compose 5 services + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# ===== AI provider switch =====
+AI_PROVIDER=openai                 # openai | anthropic
+AI_MODEL=gpt-4o-mini               # ou claude-sonnet-4-6 quando AI_PROVIDER=anthropic
+AI_API_KEY=                        # fallback usado pelo provider ativo
+OPENAI_API_KEY=                    # usado também por STT/TTS/vision
+ANTHROPIC_API_KEY=                 # quando AI_PROVIDER=anthropic
+
+# ===== STT =====
+STT_PROVIDER=openai
+STT_MODEL=whisper-1
+STT_API_KEY=
+
+# ===== TTS =====
+TTS_PROVIDER=openai
+TTS_MODEL=gpt-4o-mini-tts
+TTS_VOICE=alloy
+TTS_FORMAT=opus                    # PTT nativo do WhatsApp
+TTS_API_KEY=
+
+# ===== Vision =====
+VISION_ENABLED=true
+VISION_MODEL=gpt-4o-mini
+
+# ===== Database (asyncpg) =====
+DATABASE_URL=postgresql+asyncpg://contactpro:contactpro@db:5432/contactpro
+POSTGRES_USER=contactpro
+POSTGRES_PASSWORD=contactpro
+POSTGRES_DB=contactpro
+
+# ===== Redis (exigido pelo Evolution v2) =====
+REDIS_URL=redis://redis:6379
+
+# ===== Evolution API v2.3.7 =====
+EVOLUTION_API_URL=http://evolution:8080
+EVOLUTION_API_KEY=change-me-on-first-run
+EVOLUTION_INSTANCE=contactpro
+EVOLUTION_WEBHOOK_URL=http://backend:8000/api/webhooks/evolution
+EVOLUTION_DATABASE_PROVIDER=postgresql
+EVOLUTION_DATABASE_URI=postgresql://contactpro:contactpro@db:5432/contactpro?schema=evolution_api
+EVOLUTION_CACHE_REDIS_URI=redis://redis:6379/6
+EVOLUTION_CACHE_REDIS_PREFIX=evolution
+
+# ===== App =====
+APP_PORT=8000
+FRONTEND_PORT=5173
+LOG_LEVEL=INFO
+SOCKET_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -115,3 +115,29 @@ Formato:
 **Tempo gasto:** ~25 min
 
 **Smoke test:** `npm run build` → tsc strict OK, Vite build OK (22 KB CSS, 223 KB JS gzip 70 KB).
+
+---
+
+## 2026-04-25 11:15 — PR #4: docker-compose 5 services + .env.example
+
+**Decisões:**
+- 5 serviços: `db` (postgres:16-alpine), `redis` (redis:7-alpine, AOF on), `evolution` (evoapicloud/evolution-api:v2.3.7), `backend`, `frontend`.
+- Postgres compartilhado: schema `evolution_api` para Evolution + `public` para o backend (init SQL em `docker/postgres-init/00-create-schemas.sql`).
+- `depends_on` com `condition: service_healthy` (db, redis) — backend só sobe depois que infra está pronta.
+- Healthchecks reais em todos os serviços críticos (`pg_isready`, `redis-cli ping`, `wget` na Evolution, `curl` no backend).
+- `EVOLUTION_WEBHOOK_URL` aponta para `http://backend:8000/...` (rede interna do compose, não `localhost`).
+- Variáveis sensíveis sem default no compose (`AI_API_KEY`, `EVOLUTION_API_KEY`, etc.) — vêm do `.env`.
+
+**Dificuldades:**
+- Evolution v2 exige Postgres + Redis (validado na pesquisa); montar tudo em um único compose simplifica setup mas aumenta tempo de cold start (~30s).
+
+**Trade-offs:**
+- Volume `evolution_instances:/evolution/instances` persiste sessão Baileys. Documentar reset (`docker volume rm`) no README final.
+- Sem Nginx / TLS / proxy reverso — fora de escopo (challenge não exige).
+
+**Sugestões da IA rejeitadas/alteradas:**
+- IA inicial sugeriu `evoapicloud/evolution-api:latest`; ajustei para tag fixa `v2.3.7` (reprodutibilidade).
+
+**Tempo gasto:** ~15 min
+
+**Smoke test:** `docker compose config --quiet` → válido (warnings esperados sobre vars sem `.env`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,148 @@
+# Docker Compose — Contact Pro chatbot stack
+# 5 serviços: db (Postgres) + redis + evolution + backend + frontend
+# Postgres é compartilhado: schema "evolution_api" para Evolution API,
+# schema "public" (default) para o backend FastAPI.
+# Sessão WhatsApp persiste em volume `evolution_instances`.
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: contactpro-db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-contactpro}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-contactpro}
+      POSTGRES_DB: ${POSTGRES_DB:-contactpro}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-contactpro} -d ${POSTGRES_DB:-contactpro}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  redis:
+    image: redis:7-alpine
+    container_name: contactpro-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  evolution:
+    image: evoapicloud/evolution-api:v2.3.7
+    container_name: contactpro-evolution
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      SERVER_PORT: 8080
+      SERVER_URL: ${EVOLUTION_API_URL:-http://evolution:8080}
+      AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY}
+      AUTHENTICATION_EXPOSE_IN_FETCH_INSTANCES: "true"
+      DEL_INSTANCE: "false"
+      LANGUAGE: pt-BR
+      DATABASE_PROVIDER: ${EVOLUTION_DATABASE_PROVIDER:-postgresql}
+      DATABASE_CONNECTION_URI: ${EVOLUTION_DATABASE_URI}
+      DATABASE_CONNECTION_CLIENT_NAME: evolution_exchange
+      DATABASE_SAVE_DATA_INSTANCE: "true"
+      DATABASE_SAVE_DATA_NEW_MESSAGE: "true"
+      DATABASE_SAVE_MESSAGE_UPDATE: "true"
+      DATABASE_SAVE_DATA_CONTACTS: "true"
+      DATABASE_SAVE_DATA_CHATS: "true"
+      DATABASE_SAVE_DATA_LABELS: "false"
+      DATABASE_SAVE_DATA_HISTORIC: "false"
+      CACHE_REDIS_ENABLED: "true"
+      CACHE_REDIS_URI: ${EVOLUTION_CACHE_REDIS_URI:-redis://redis:6379/6}
+      CACHE_REDIS_PREFIX_KEY: ${EVOLUTION_CACHE_REDIS_PREFIX:-evolution}
+      CACHE_REDIS_SAVE_INSTANCES: "true"
+      CACHE_LOCAL_ENABLED: "false"
+      WEBHOOK_GLOBAL_ENABLED: "false"
+      LOG_LEVEL: "ERROR,WARN,LOG,INFO"
+      LOG_COLOR: "true"
+      LOG_BAILEYS: warn
+      QRCODE_LIMIT: "30"
+      CONFIG_SESSION_PHONE_VERSION: 2.3000.1023204200
+    volumes:
+      - evolution_instances:/evolution/instances
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: contactpro-backend
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      evolution:
+        condition: service_started
+    environment:
+      APP_PORT: ${APP_PORT:-8000}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      AI_PROVIDER: ${AI_PROVIDER:-openai}
+      AI_MODEL: ${AI_MODEL:-gpt-4o-mini}
+      AI_API_KEY: ${AI_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      STT_PROVIDER: ${STT_PROVIDER:-openai}
+      STT_MODEL: ${STT_MODEL:-whisper-1}
+      STT_API_KEY: ${STT_API_KEY}
+      TTS_PROVIDER: ${TTS_PROVIDER:-openai}
+      TTS_MODEL: ${TTS_MODEL:-gpt-4o-mini-tts}
+      TTS_VOICE: ${TTS_VOICE:-alloy}
+      TTS_FORMAT: ${TTS_FORMAT:-opus}
+      TTS_API_KEY: ${TTS_API_KEY}
+      VISION_ENABLED: ${VISION_ENABLED:-true}
+      VISION_MODEL: ${VISION_MODEL:-gpt-4o-mini}
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      EVOLUTION_API_URL: ${EVOLUTION_API_URL:-http://evolution:8080}
+      EVOLUTION_API_KEY: ${EVOLUTION_API_KEY}
+      EVOLUTION_INSTANCE: ${EVOLUTION_INSTANCE:-contactpro}
+      EVOLUTION_WEBHOOK_URL: ${EVOLUTION_WEBHOOK_URL:-http://backend:8000/api/webhooks/evolution}
+      SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-http://localhost:5173}
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: contactpro-frontend
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+
+volumes:
+  postgres_data:
+  redis_data:
+  evolution_instances:

--- a/docker/postgres-init/00-create-schemas.sql
+++ b/docker/postgres-init/00-create-schemas.sql
@@ -1,0 +1,4 @@
+-- Cria schemas separados para Evolution API e backend Contact Pro.
+-- Executado uma única vez no primeiro start do container Postgres.
+CREATE SCHEMA IF NOT EXISTS evolution_api AUTHORIZATION contactpro;
+CREATE SCHEMA IF NOT EXISTS contactpro AUTHORIZATION contactpro;


### PR DESCRIPTION
5 servicos com depends_on + healthchecks:
- db (postgres:16-alpine + init SQL para schemas evolution_api e contactpro)
- redis (redis:7-alpine, AOF on)
- evolution (evoapicloud/evolution-api:v2.3.7)
- backend
- frontend
Volumes: postgres_data, redis_data, evolution_instances.
EVOLUTION_WEBHOOK_URL na rede interna (http://backend:8000).
.env.example com placeholders para AI_PROVIDER switch + STT + TTS + vision + Evolution.

Smoke: docker compose config --quiet -> valido.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)