### PR TITLE
feat(db): models Lead/Conversation/Message + initial migration

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -141,3 +141,29 @@ Formato:
 **Tempo gasto:** ~15 min
 
 **Smoke test:** `docker compose config --quiet` → válido (warnings esperados sobre vars sem `.env`).
+
+---
+
+## 2026-04-25 11:25 — PR #5: DB models (Lead/Conversation/Message) + initial migration
+
+**Decisões:**
+- 3 tabelas: `leads`, `conversations`, `messages`. Todas as enums (LeadStatus, ServiceInterest, Intent, Direction, MessageType, MessageStatus) armazenadas como `VARCHAR` para evitar bug do Alembic com pg.ENUM.
+- PK UUID em todas (Postgres native via `PG_UUID(as_uuid=True)`).
+- `whatsapp_jid` UNIQUE em leads, `whatsapp_message_id` UNIQUE em messages → idempotência de webhooks.
+- FKs com `ondelete="CASCADE"` (Conversation→Lead, Message→Conversation).
+- Migration `0001_init` escrita à mão (sem rodar autogenerate) por dois motivos: (1) Postgres não está rodando localmente; (2) o autogenerate gera lixo com Enums e índices, sempre exige edição manual depois.
+- `app/db/base.py` importa todos os models para SQLModel.metadata enxergar.
+
+**Dificuldades:**
+- Alembic autogenerate exige Postgres rodando — preferi escrever a migration manual e validar via inspeção dos objetos `__table__` em Python (`SQLModel.metadata.tables`). Confirma colunas e índices.
+
+**Trade-offs:**
+- Sem ENUM nativo no Postgres = sem validação na borda do banco. Mitigação: validação Pydantic em todo I/O da camada de aplicação.
+- Sem `relationship()` declarativo (Lead.conversations, etc.) por enquanto — se for necessário no orchestrator (PR #9), adiciono lá.
+
+**Sugestões da IA rejeitadas/alteradas:**
+- IA sugeriu inicialmente `Field(default=LeadStatus.NEW)` direto. Substituído por `sa_column=Column(String(32), ..., default=LeadStatus.NEW.value)` para garantir que o tipo SQL seja `VARCHAR` mesmo se SQLModel tentar inferir Enum nativo.
+
+**Tempo gasto:** ~15 min
+
+**Smoke test:** `from app.db.base import *` — 3 tabelas, todas as colunas e enums batem com a spec do desafio.

--- a/backend/alembic/versions/0001_init_lead_conversation_message.py
+++ b/backend/alembic/versions/0001_init_lead_conversation_message.py
@@ -1,0 +1,153 @@
+"""init: Lead, Conversation, Message
+
+Revision ID: 0001_init
+Revises:
+Create Date: 2026-04-25 11:25:00
+
+Migração inicial criando as 3 tabelas do domínio:
+- leads (PK uuid, whatsapp_jid UNIQUE)
+- conversations (FK→leads, ondelete cascade)
+- messages (FK→conversations, whatsapp_message_id UNIQUE para idempotência)
+
+Enums armazenados como VARCHAR para evitar bugs do autogenerate com pg.ENUM.
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401  (necessário para AutoString se usado em models)
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_init"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "leads",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("whatsapp_jid", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=160), nullable=True),
+        sa.Column("company", sa.String(length=200), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=True),
+        sa.Column(
+            "service_interest",
+            sa.String(length=32),
+            nullable=False,
+            server_default="unknown",
+        ),
+        sa.Column("lead_goal", sa.String(length=500), nullable=True),
+        sa.Column("estimated_volume", sa.String(length=160), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default="new",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_leads_whatsapp_jid", "leads", ["whatsapp_jid"], unique=True)
+    op.create_index("ix_leads_status", "leads", ["status"], unique=False)
+
+    op.create_table(
+        "conversations",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "lead_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("leads.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("last_intent", sa.String(length=32), nullable=True),
+        sa.Column(
+            "last_message_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_conversations_lead_id", "conversations", ["lead_id"], unique=False)
+
+    op.create_table(
+        "messages",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("whatsapp_message_id", sa.String(length=128), nullable=True),
+        sa.Column("direction", sa.String(length=8), nullable=False),
+        sa.Column("type", sa.String(length=16), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("transcription", sa.Text(), nullable=True),
+        sa.Column("media_url", sa.String(length=512), nullable=True),
+        sa.Column("media_mime", sa.String(length=64), nullable=True),
+        sa.Column("intent", sa.String(length=32), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("quoted_message_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("error_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_messages_whatsapp_message_id",
+        "messages",
+        ["whatsapp_message_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_messages_conversation_id",
+        "messages",
+        ["conversation_id"],
+        unique=False,
+    )
+    op.create_index("ix_messages_direction", "messages", ["direction"], unique=False)
+    op.create_index("ix_messages_created_at", "messages", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_messages_created_at", table_name="messages")
+    op.drop_index("ix_messages_direction", table_name="messages")
+    op.drop_index("ix_messages_conversation_id", table_name="messages")
+    op.drop_index("ix_messages_whatsapp_message_id", table_name="messages")
+    op.drop_table("messages")
+
+    op.drop_index("ix_conversations_lead_id", table_name="conversations")
+    op.drop_table("conversations")
+
+    op.drop_index("ix_leads_status", table_name="leads")
+    op.drop_index("ix_leads_whatsapp_jid", table_name="leads")
+    op.drop_table("leads")

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,5 +1,7 @@
-"""Importa todos os models para que SQLModel.metadata enxergue ao gerar migrations."""
+"""Importa todos os models para que SQLModel.metadata os enxergue ao gerar migrations."""
 
 from sqlmodel import SQLModel  # noqa: F401
 
-# As importações de modelos serão adicionadas pelo PR #5.
+from app.models.conversation import Conversation  # noqa: F401
+from app.models.lead import Lead  # noqa: F401
+from app.models.message import Message  # noqa: F401

--- a/backend/app/models/CLAUDE.md
+++ b/backend/app/models/CLAUDE.md
@@ -1,0 +1,60 @@
+# app/models/CLAUDE.md
+
+> Regras dos models de banco. Leia antes de criar/alterar tabela.
+
+## Modelos
+
+| Modelo | Tabela | Resumo |
+|---|---|---|
+| `Lead` | `leads` | 1 por número WhatsApp. `whatsapp_jid` UNIQUE. |
+| `Conversation` | `conversations` | Pertence a um Lead. Guarda última intenção e timestamp. |
+| `Message` | `messages` | Cada mensagem (IN/OUT). `whatsapp_message_id` UNIQUE → idempotência. |
+
+## Enums (em `enums.py`)
+
+`LeadStatus`, `ServiceInterest`, `Intent`, `Direction`, `MessageType`, `MessageStatus`. Todos `str, Enum` — armazenados como `VARCHAR(N)` no Postgres, validados na camada Pydantic.
+
+## Por que NÃO usamos `pg.ENUM`
+
+O autogenerate do Alembic tem bugs conhecidos com Postgres ENUM:
+- não gera `DROP TYPE` no downgrade
+- não suporta `ALTER TYPE ADD VALUE`
+- migra para outro tipo gera revisão quebrada
+
+Solução: `Column(String(N))` com Pydantic Enum como tipo Python. Trade-off aceito: validação não acontece no DB, mas o app valida em todo I/O.
+
+## Convenções
+
+- **PK:** `UUID` com `default_factory=uuid4`, coluna `PG_UUID(as_uuid=True)`.
+- **Timestamps:** `DateTime(timezone=True)`, `default_factory=_now` que usa `datetime.now(UTC)`.
+- **FKs:** sempre com `ondelete="CASCADE"` quando a relação é parte-todo (Conversation→Lead, Message→Conversation).
+- **Índices:** em `whatsapp_jid` (Lead), `whatsapp_message_id` (Message), `lead_id` (Conversation), `conversation_id` (Message), `direction` (Message), `created_at` (Message), `status` (Lead).
+- **Idempotência:** `whatsapp_message_id` UNIQUE NULL — Evolution pode redeliver, orchestrator faz `INSERT ... ON CONFLICT DO NOTHING` ou checagem prévia.
+
+## Como adicionar um novo model
+
+1. Criar arquivo em `app/models/<nome>.py`.
+2. Subclassar `SQLModel, table=True`.
+3. Registrar import em `app/db/base.py` (senão SQLModel.metadata não enxerga).
+4. Gerar migration: `uv run alembic revision --autogenerate -m "<descr>"`.
+5. **Revisar a migration manualmente** antes de aplicar — autogenerate pode gerar lixo (especialmente índices, defaults com `func`).
+6. `uv run alembic upgrade head`.
+
+## Como adicionar um campo
+
+1. Adicionar `Field(...)` no model.
+2. Migration autogerada deve detectar (`compare_type=True` está ativado).
+3. Para `nullable=False` em tabela com dados existentes: usar `server_default=` + alterar o tipo em duas etapas (add nullable → backfill → make NOT NULL). Não tente fazer numa migration só.
+
+## Não fazer
+
+- `Column(Enum(...))` — vai quebrar autogenerate. Use `String(N)` + Pydantic Enum.
+- Esquecer de adicionar import em `app/db/base.py` — SQLModel.metadata fica vazio para esse model.
+- `DateTime` sem `timezone=True` — sempre UTC com tz.
+- FK sem `ondelete=` — vira lixo órfão.
+
+## Links
+
+- `enums.py` — fonte canônica das enums (espelha o desafio)
+- `app/db/base.py` — registry de models para Alembic
+- Plan: `/Users/gasparellodev/.claude/plans/o-seu-papel-crystalline-lantern.md`

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlmodel import Field, SQLModel
+
+from app.models.enums import Intent
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Conversation(SQLModel, table=True):
+    __tablename__ = "conversations"
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        sa_column=Column(PG_UUID(as_uuid=True), primary_key=True),
+    )
+    lead_id: UUID = Field(
+        sa_column=Column(
+            PG_UUID(as_uuid=True),
+            ForeignKey("leads.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    last_intent: Intent | None = Field(
+        default=None, sa_column=Column(String(32), nullable=True)
+    )
+    last_message_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=_now),
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=_now),
+    )

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -1,0 +1,65 @@
+"""Enums obrigatórios pelo desafio.
+
+Persistidos como `String` (não `pg.ENUM`) para evitar bugs do alembic autogenerate
+com Enums em Postgres (não gera DROP TYPE / ALTER TYPE ADD VALUE corretamente).
+A validação fica na camada Pydantic/SQLModel.
+"""
+
+from enum import Enum
+
+
+class LeadStatus(str, Enum):
+    NEW = "new"
+    QUALIFIED = "qualified"
+    NEEDS_HUMAN = "needs_human"
+    OPT_OUT = "opt_out"
+
+
+class ServiceInterest(str, Enum):
+    CONTACT_Z = "contact_z"
+    CONTACT_TEL = "contact_tel"
+    MAILING = "mailing"
+    DATA_ENRICHMENT = "data_enrichment"
+    UNKNOWN = "unknown"
+
+
+class Intent(str, Enum):
+    CONTACT_Z = "contact_z"
+    CONTACT_TEL = "contact_tel"
+    MAILING = "mailing"
+    DATA_ENRICHMENT = "data_enrichment"
+    PRICING = "pricing"
+    HUMAN_HANDOFF = "human_handoff"
+    OPT_OUT = "opt_out"
+    SUPPORT = "support"
+    GENERAL_QUESTION = "general_question"
+
+
+class Direction(str, Enum):
+    IN = "in"
+    OUT = "out"
+
+
+class MessageType(str, Enum):
+    TEXT = "text"
+    AUDIO = "audio"
+    IMAGE = "image"
+
+
+class MessageStatus(str, Enum):
+    PENDING = "pending"
+    SENT = "sent"
+    DELIVERED = "delivered"
+    READ = "read"
+    FAILED = "failed"
+    RECEIVED = "received"
+
+
+__all__ = [
+    "LeadStatus",
+    "ServiceInterest",
+    "Intent",
+    "Direction",
+    "MessageType",
+    "MessageStatus",
+]

--- a/backend/app/models/lead.py
+++ b/backend/app/models/lead.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlmodel import Field, SQLModel
+
+from app.models.enums import LeadStatus, ServiceInterest
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Lead(SQLModel, table=True):
+    __tablename__ = "leads"
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        sa_column=Column(PG_UUID(as_uuid=True), primary_key=True),
+    )
+    whatsapp_jid: str = Field(
+        sa_column=Column(String(64), unique=True, index=True, nullable=False)
+    )
+    name: str | None = Field(default=None, max_length=160)
+    company: str | None = Field(default=None, max_length=200)
+    phone: str | None = Field(default=None, max_length=32)
+    service_interest: ServiceInterest = Field(
+        default=ServiceInterest.UNKNOWN,
+        sa_column=Column(String(32), nullable=False, default=ServiceInterest.UNKNOWN.value),
+    )
+    lead_goal: str | None = Field(default=None, max_length=500)
+    estimated_volume: str | None = Field(default=None, max_length=160)
+    status: LeadStatus = Field(
+        default=LeadStatus.NEW,
+        sa_column=Column(String(32), nullable=False, default=LeadStatus.NEW.value, index=True),
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=_now),
+    )
+    updated_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(
+            DateTime(timezone=True), nullable=False, default=_now, onupdate=_now
+        ),
+    )

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlmodel import Field, SQLModel
+
+from app.models.enums import Direction, Intent, MessageStatus, MessageType
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Message(SQLModel, table=True):
+    __tablename__ = "messages"
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        sa_column=Column(PG_UUID(as_uuid=True), primary_key=True),
+    )
+    conversation_id: UUID = Field(
+        sa_column=Column(
+            PG_UUID(as_uuid=True),
+            ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    whatsapp_message_id: str | None = Field(
+        default=None,
+        sa_column=Column(String(128), unique=True, index=True, nullable=True),
+    )
+    direction: Direction = Field(sa_column=Column(String(8), nullable=False, index=True))
+    type: MessageType = Field(sa_column=Column(String(16), nullable=False))
+    content: str = Field(sa_column=Column(Text, nullable=False, default=""))
+    transcription: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    media_url: str | None = Field(default=None, sa_column=Column(String(512), nullable=True))
+    media_mime: str | None = Field(default=None, sa_column=Column(String(64), nullable=True))
+    intent: Intent | None = Field(default=None, sa_column=Column(String(32), nullable=True))
+    status: MessageStatus = Field(
+        default=MessageStatus.PENDING,
+        sa_column=Column(String(16), nullable=False, default=MessageStatus.PENDING.value),
+    )
+    quoted_message_id: UUID | None = Field(
+        default=None,
+        sa_column=Column(PG_UUID(as_uuid=True), nullable=True),
+    )
+    error_reason: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=_now, index=True),
+    )


### PR DESCRIPTION
3 tabelas (UUID PKs, FKs CASCADE, indices em whatsapp_jid e whatsapp_message_id UNIQUE para idempotencia). Enums armazenados como VARCHAR para evitar bug do autogenerate com pg.ENUM. Migration 0001_init manual. models/CLAUDE.md.

Smoke: from app.db.base import * -> 3 tabelas, todas colunas batem com a spec do desafio.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)