### PR TITLE
feat(ai): provider abstraction (OpenAI + Anthropic) + KB Contact Pro

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -222,3 +222,33 @@ Formato:
 **Tempo gasto:** ~10 min
 
 **Smoke test:** `npm run build` → tsc strict + Vite verde.
+
+---
+
+## 2026-04-25 12:25 — PR #8: AI provider abstraction + KB Contact Pro
+
+**Decisões:**
+- `base.py`: `AIProvider` Protocol com 2 métodos (`generate_response`, `describe_image`). Output sempre `AIResponse{reply, intent, lead_extracted, status_suggestion}` Pydantic.
+- `OpenAIProvider`: `client.chat.completions.parse(response_format=AIResponse)` — pattern recomendado em 2026 (mais robusto que `response_format={"type":"json_schema",...}` cru).
+- `AnthropicProvider`: `tool_choice={"type":"tool","name":"emit_response"}` forçado, com `input_schema` JSON espelho do `AIResponse`. System prompt em block list com `cache_control: ephemeral` (reduz custo da KB ~90% após 1ª chamada).
+- `factory.py:get_ai_provider()` lru_cache lê `settings.ai_provider`. Outros módulos só importam o factory.
+- `knowledge_base/contact_pro.md` cobre os 5 serviços + tom + regras de qualificação.
+- `prompts.py:build_system_prompt` concatena regras + KB; lru_cache.
+
+**Dificuldades:**
+- Path da KB falhou no primeiro smoke (faltava 1 nível de `parent`); corrigido para `parent.parent.parent` a partir de `prompts.py`.
+- Anthropic tool_use schema precisa replicar exatamente os enums do desafio — qualquer divergência rejeitaria a resposta. Replicado à mão; futuro: gerar a partir do Pydantic via `model_json_schema()`.
+
+**Trade-offs:**
+- Sem chamada real à OpenAI/Anthropic ainda (sem chaves nesta máquina). Validação acontece com smoke do compose-up + chave do usuário.
+- Vision usa o mesmo provider escolhido em `AI_PROVIDER` — mais simples que ter um terceiro env. Se o usuário usar Anthropic + quiser GPT vision, terá que fazer override manual.
+
+**Sugestões da IA rejeitadas/alteradas:**
+- IA inicial sugeriu adicionar `cache_control` em todo bloco system. Mantive só no bloco da KB (reduz miss em cache invalidation).
+- IA sugeriu `temperature=0.7` para conversação; rebaixei para 0.4 (mais previsível, ainda natural).
+
+**Tempo gasto:** ~25 min
+
+**Smoke test:** `from app.services.ai.factory import get_ai_provider` + `build_system_prompt()` retorna 4307 chars; AIResponse fields batem.
+
+**Pendente:** smoke test real com chave (próxima fase no compose-up).

--- a/backend/app/knowledge_base/contact_pro.md
+++ b/backend/app/knowledge_base/contact_pro.md
@@ -1,0 +1,46 @@
+# Base de conhecimento — Contact Pro
+
+A **Contact Pro** desenvolve soluções de comunicação, atendimento, marketing, vendas, automação e IA. O bot deste sistema é o **assistente comercial** que faz o atendimento inicial dos leads.
+
+## Serviços principais
+
+### 1. Contact Z
+Plataforma para **atendimento, automação e campanhas via WhatsApp**, com IA e integração de canais digitais. Cobre disparo de campanhas, atendimento humano + IA, fluxos automatizados, integração com CRMs.
+**Quando indicar:** lead quer automatizar atendimento via WhatsApp, fazer campanhas em escala, ou unificar canais digitais.
+
+### 2. Contact Tel
+Plataforma de **agentes de voz / URA reversa** que faz e recebe ligações automaticamente, registra interações e apoia operações de cobrança, vendas, pesquisa ou atendimento por voz.
+**Quando indicar:** lead menciona ligações automáticas, URA, cobrança por voz, pesquisa por telefone, qualificação ativa via call.
+
+### 3. Captação / fornecimento de mailings
+Listas segmentadas de contatos para campanhas de vendas, marketing, cobrança ou pesquisa.
+**Quando indicar:** lead pergunta por base de contatos, mailing list, leads frios para prospecção.
+
+### 4. Enriquecimento e higienização de dados
+Atualiza, valida e enriquece bases existentes (telefone, e-mail, dados cadastrais).
+**Quando indicar:** lead já tem base e fala em "limpar", "validar", "atualizar" ou "complementar".
+
+### 5. Atendimento e vendas com IA
+Agentes inteligentes para qualificação, automação comercial e atendimento integrado a múltiplos canais (WhatsApp, voz, e-mail, web).
+**Quando indicar:** lead quer aplicar IA em qualificação, automação comercial, ou unir vários canais com agentes inteligentes.
+
+## Como o bot deve agir
+
+- **Tom**: cordial, objetivo, profissional. Em português do Brasil.
+- **Sem inventar preços.** Se perguntarem valor, qualificar antes (volume, segmento, objetivo) e dizer que um especialista retorna com proposta personalizada.
+- **Perguntas de qualificação** (uma por vez quando possível):
+  - Você representa uma empresa? Qual segmento?
+  - O atendimento seria para vendas, suporte, cobrança ou pesquisa?
+  - Você já tem uma base de contatos ou precisa que a Contact Pro forneça os dados?
+  - Qual é o volume aproximado da sua campanha ou operação?
+  - Pretende automatizar atendimento via WhatsApp, fazer ligações automáticas, contratar mailing ou enriquecer base existente?
+- **Status do lead** (regras de negócio):
+  - `qualified` quando o bot tem nome/empresa OU intenção clara em algum serviço + volume/objetivo plausível.
+  - `needs_human` quando o lead pede expressamente para falar com humano, ou faz pergunta complexa fora do escopo.
+  - `opt_out` quando o lead diz que não tem interesse, pede para parar, ou demonstra desinteresse claro.
+  - `new` enquanto não cair em nenhum dos três acima.
+
+## Limites do bot
+- Não promete prazos.
+- Não envia documentos.
+- Não substitui o time comercial — pode encaminhar (`needs_human`) quando preciso.

--- a/backend/app/services/ai/CLAUDE.md
+++ b/backend/app/services/ai/CLAUDE.md
@@ -1,0 +1,47 @@
+# app/services/ai/CLAUDE.md
+
+> Contrato dos providers de IA. Leia antes de adicionar/alterar.
+
+## Princípios
+
+1. **Output sempre estruturado.** O orchestrator depende de `AIResponse{reply, intent, lead_extracted, status_suggestion}`. Cada provider faz o que for preciso para garantir esse shape.
+2. **OpenAI**: `client.chat.completions.parse(response_format=AIResponse)`. Não usar `response_format={type: json_schema, ...}` cru (mais frágil em 2026).
+3. **Anthropic**: `tool_choice={"type":"tool","name":"emit_response"}` forçado, com `input_schema` explícito (espelha o `AIResponse`). System prompt em **block list** com `cache_control: ephemeral` para reduzir custo do KB Contact Pro em ~90% após a 1ª chamada.
+4. **Não usar `extended_thinking`** no Anthropic provider — incompatível com tool_choice forçado.
+5. **Vision** vive no mesmo provider (mesma API key); orchestrator descreve a imagem em texto e alimenta o pipeline de conversa.
+
+## Como adicionar um novo provider (Gemini, Groq, OpenRouter)
+
+1. Criar arquivo `app/services/ai/<nome>_provider.py`.
+2. Implementar a interface `AIProvider` (Protocol em `base.py`): `name`, `model`, `generate_response`, `describe_image`.
+3. Adicionar branch no `factory.py`.
+4. Adicionar option em `core/config.py:Settings.ai_provider`.
+5. Smoke test ambos os métodos com chave real e marcar no DEVELOPMENT_LOG.
+
+## Provider switch
+
+```env
+AI_PROVIDER=openai            # ou anthropic
+AI_MODEL=gpt-4o-mini          # ou claude-sonnet-4-6
+AI_API_KEY=...                # fallback
+OPENAI_API_KEY=...            # explícito (também usado por STT/TTS/vision)
+ANTHROPIC_API_KEY=...         # explícito
+```
+
+`active_ai_api_key` em `Settings` resolve a chave certa: prefere a explícita do provider, cai para `AI_API_KEY` como fallback.
+
+## Não fazer
+
+- Importar `OpenAIProvider`/`AnthropicProvider` direto em outros módulos — use `get_ai_provider()`.
+- Inserir `temperature=0` no provider Anthropic — devolve respostas robóticas. Default `0.4`.
+- Modificar `EMIT_TOOL_SCHEMA` sem refletir em `AIResponse` (test break imediato).
+- Usar `print` para logar respostas — `logger.info({...})` estruturado.
+- Hard-code de prompt em outro lugar — único lugar é `prompts.py:build_system_prompt`.
+
+## Links
+
+- `base.py` — Protocol + `AIResponse` (contrato)
+- `prompts.py:build_system_prompt` — concat de regras + KB
+- `app/knowledge_base/contact_pro.md` — KB
+- `factory.py` — switch
+- Plano: `/Users/gasparellodev/.claude/plans/o-seu-papel-crystalline-lantern.md`

--- a/backend/app/services/ai/anthropic_provider.py
+++ b/backend/app/services/ai/anthropic_provider.py
@@ -1,0 +1,171 @@
+"""Anthropic provider — structured output via tool_choice + cache_control no system prompt."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from anthropic import AsyncAnthropic
+
+from app.core.config import Settings, get_settings
+from app.services.ai.base import AIResponse, ChatTurn
+
+logger = logging.getLogger(__name__)
+
+# Schema do tool — mesmo shape do AIResponse Pydantic.
+EMIT_TOOL_SCHEMA: dict[str, Any] = {
+    "name": "emit_response",
+    "description": (
+        "Emite a resposta estruturada do assistente comercial."
+        " Sempre que receber input do usuário, chame esta tool com a estrutura completa."
+    ),
+    "input_schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["reply", "intent", "lead_extracted"],
+        "properties": {
+            "reply": {"type": "string"},
+            "intent": {
+                "type": "string",
+                "enum": [
+                    "contact_z",
+                    "contact_tel",
+                    "mailing",
+                    "data_enrichment",
+                    "pricing",
+                    "human_handoff",
+                    "opt_out",
+                    "support",
+                    "general_question",
+                ],
+            },
+            "lead_extracted": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "company": {"type": ["string", "null"]},
+                    "phone": {"type": ["string", "null"]},
+                    "service_interest": {
+                        "type": ["string", "null"],
+                        "enum": [
+                            "contact_z",
+                            "contact_tel",
+                            "mailing",
+                            "data_enrichment",
+                            "unknown",
+                            None,
+                        ],
+                    },
+                    "lead_goal": {"type": ["string", "null"]},
+                    "estimated_volume": {"type": ["string", "null"]},
+                },
+            },
+            "status_suggestion": {
+                "type": ["string", "null"],
+                "enum": ["new", "qualified", "needs_human", "opt_out", None],
+            },
+        },
+    },
+}
+
+
+class AnthropicProvider:
+    name = "anthropic"
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.model = self.settings.ai_model
+        if self.model == "gpt-4o-mini":  # fallback default não faz sentido aqui
+            self.model = "claude-sonnet-4-6"
+        self.client = AsyncAnthropic(api_key=self.settings.active_ai_api_key)
+
+    async def generate_response(
+        self,
+        *,
+        system_prompt: str,
+        history: list[ChatTurn],
+        user_message: str,
+    ) -> AIResponse:
+        # System em block list para suportar prompt cache (cache_control: ephemeral).
+        system_blocks: list[dict[str, Any]] = [
+            {
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        messages: list[dict[str, Any]] = []
+        for turn in history:
+            messages.append({"role": turn.role, "content": turn.content})
+        messages.append({"role": "user", "content": user_message})
+
+        try:
+            resp = await self.client.messages.create(
+                model=self.model,
+                max_tokens=800,
+                system=system_blocks,
+                messages=messages,
+                tools=[EMIT_TOOL_SCHEMA],
+                tool_choice={"type": "tool", "name": "emit_response"},
+                temperature=0.4,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("anthropic_generate_failed", extra={"error": str(exc)})
+            raise
+
+        # tool_use block é o primeiro com type=tool_use
+        for block in resp.content:
+            if getattr(block, "type", None) == "tool_use":
+                payload = block.input  # já é dict
+                return AIResponse.model_validate(payload)
+
+        raise RuntimeError("anthropic não emitiu tool_use esperado")
+
+    async def describe_image(
+        self, *, image_base64: str, mime_type: str, hint: str = ""
+    ) -> str:
+        text_prompt = (
+            "Descreva sucintamente em português o que aparece nesta imagem para um "
+            "assistente comercial entender o contexto."
+        )
+        if hint:
+            text_prompt += f" Contexto adicional: {hint}"
+
+        resp = await self.client.messages.create(
+            model=self.model,
+            max_tokens=300,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": mime_type,
+                                "data": image_base64,
+                            },
+                        },
+                        {"type": "text", "text": text_prompt},
+                    ],
+                }
+            ],
+        )
+
+        parts: list[str] = []
+        for block in resp.content:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(text)
+        return "\n".join(parts).strip()
+
+
+# Helper para ler dict tipados (caso anthropic SDK retorne via .dict())
+def _to_dict(obj: Any) -> dict[str, Any]:
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    return json.loads(json.dumps(obj, default=str))

--- a/backend/app/services/ai/base.py
+++ b/backend/app/services/ai/base.py
@@ -1,0 +1,62 @@
+"""Contrato comum dos providers de IA. OpenAI e Anthropic implementam.
+
+A camada acima (orchestrator) só consome `AIProvider` — nunca importa
+implementações concretas.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import Intent, LeadStatus, ServiceInterest
+
+ChatRole = Literal["user", "assistant"]
+
+
+class ChatTurn(BaseModel):
+    role: ChatRole
+    content: str
+
+
+class LeadExtracted(BaseModel):
+    """Campos que a IA tenta extrair da conversa para preencher o Lead."""
+
+    name: str | None = None
+    company: str | None = None
+    phone: str | None = None
+    service_interest: ServiceInterest | None = None
+    lead_goal: str | None = None
+    estimated_volume: str | None = None
+
+
+class AIResponse(BaseModel):
+    """Saída estruturada padronizada — mesma forma para qualquer provider."""
+
+    reply: str = Field(..., description="Mensagem em PT-BR a ser enviada ao lead.")
+    intent: Intent = Field(..., description="Intenção classificada da última mensagem.")
+    lead_extracted: LeadExtracted = Field(default_factory=LeadExtracted)
+    status_suggestion: LeadStatus | None = Field(
+        default=None,
+        description="Sugestão de status do lead após esta resposta.",
+    )
+
+
+class AIProvider(Protocol):
+    """Interface mínima que orchestrator espera de qualquer provider."""
+
+    name: str
+    model: str
+
+    async def generate_response(
+        self,
+        *,
+        system_prompt: str,
+        history: list[ChatTurn],
+        user_message: str,
+    ) -> AIResponse: ...
+
+    async def describe_image(self, *, image_base64: str, mime_type: str, hint: str = "") -> str:
+        """Retorna descrição textual da imagem (para alimentar o pipeline de texto)."""
+        ...

--- a/backend/app/services/ai/factory.py
+++ b/backend/app/services/ai/factory.py
@@ -1,0 +1,22 @@
+"""Factory que escolhe o provider de IA conforme `settings.ai_provider`.
+
+Outros módulos NUNCA importam OpenAIProvider/AnthropicProvider diretamente —
+sempre via `get_ai_provider()`.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.core.config import get_settings
+from app.services.ai.anthropic_provider import AnthropicProvider
+from app.services.ai.base import AIProvider
+from app.services.ai.openai_provider import OpenAIProvider
+
+
+@lru_cache
+def get_ai_provider() -> AIProvider:
+    settings = get_settings()
+    if settings.ai_provider == "anthropic":
+        return AnthropicProvider(settings)
+    return OpenAIProvider(settings)

--- a/backend/app/services/ai/openai_provider.py
+++ b/backend/app/services/ai/openai_provider.py
@@ -1,0 +1,80 @@
+"""OpenAI provider — usa chat.completions.parse para structured output Pydantic."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from app.core.config import Settings, get_settings
+from app.services.ai.base import AIResponse, ChatTurn
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider:
+    name = "openai"
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.model = self.settings.ai_model
+        self.client = AsyncOpenAI(
+            api_key=self.settings.active_ai_api_key,
+        )
+
+    async def generate_response(
+        self,
+        *,
+        system_prompt: str,
+        history: list[ChatTurn],
+        user_message: str,
+    ) -> AIResponse:
+        messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+        for turn in history:
+            messages.append({"role": turn.role, "content": turn.content})
+        messages.append({"role": "user", "content": user_message})
+
+        try:
+            completion = await self.client.chat.completions.parse(
+                model=self.model,
+                messages=messages,
+                response_format=AIResponse,
+                temperature=0.4,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("openai_generate_failed", extra={"error": str(exc)})
+            raise
+
+        parsed = completion.choices[0].message.parsed
+        if parsed is None:
+            raise RuntimeError("openai returned empty parsed response")
+        return parsed
+
+    async def describe_image(
+        self, *, image_base64: str, mime_type: str, hint: str = ""
+    ) -> str:
+        prompt = (
+            "Descreva sucintamente em português o que aparece nesta imagem "
+            "para um assistente comercial entender o contexto. "
+        )
+        if hint:
+            prompt += f"Contexto adicional: {hint}"
+        completion = await self.client.chat.completions.create(
+            model=self.settings.vision_model or self.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:{mime_type};base64,{image_base64}"},
+                        },
+                    ],
+                }
+            ],
+            temperature=0.3,
+            max_tokens=300,
+        )
+        return completion.choices[0].message.content or ""

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -1,0 +1,39 @@
+"""System prompt + carregamento da KB Contact Pro."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+KB_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "knowledge_base" / "contact_pro.md"
+)
+
+
+@lru_cache
+def load_kb() -> str:
+    return KB_PATH.read_text(encoding="utf-8")
+
+
+SYSTEM_RULES = """\
+Você é o assistente comercial da Contact Pro. Atende leads pelo WhatsApp.
+
+Regras:
+- Responda sempre em português do Brasil, tom cordial, objetivo, profissional.
+- Use a base de conhecimento abaixo para falar sobre os serviços. NUNCA invente preços; quando perguntarem valor, peça antes contexto (segmento, volume, objetivo) e diga que um especialista retorna com proposta personalizada.
+- Faça perguntas de qualificação naturais — uma por vez quando possível. Não despeje formulário.
+- Quando o lead disser que não tem interesse, pedir para parar, ou demonstrar desinteresse claro, marque `status_suggestion = opt_out`.
+- Quando pedir explicitamente atendimento humano ou tiver pergunta fora do escopo, marque `status_suggestion = needs_human`.
+- Quando tiver clareza sobre serviço + volume/objetivo + identidade (nome ou empresa), marque `status_suggestion = qualified`.
+- Caso contrário, deixe `status_suggestion = null` (status segue `new`).
+- Sempre preencha `intent` com uma das opções enumeradas.
+- Em `lead_extracted`, devolva apenas o que foi explicitamente mencionado nesta conversa. Não invente.
+- Limite a resposta a ~700 caracteres (mensagens longas no WhatsApp pesam).
+
+Formato de saída: estritamente o JSON estruturado com os campos `reply`, `intent`, `lead_extracted`, `status_suggestion`.
+"""
+
+
+def build_system_prompt() -> str:
+    """Concatena regras + KB. Cacheável (a KB é estática)."""
+    return f"{SYSTEM_RULES}\n\n--- BASE DE CONHECIMENTO ---\n{load_kb()}"


### PR DESCRIPTION
AIProvider Protocol + AIResponse Pydantic { reply, intent, lead_extracted, status_suggestion }.
OpenAIProvider: chat.completions.parse(response_format=AIResponse).
AnthropicProvider: tool_choice forced (emit_response) + cache_control: ephemeral no system prompt (reduz custo KB ~90% apos 1a chamada).
Vision multimodal em ambos.
KB Contact Pro com 5 servicos + tom + qualificacao.
Factory via env (lru_cache).
services/ai/CLAUDE.md.

Smoke: build_system_prompt -> 4307 chars; AIResponse fields batem.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)