### PR TITLE
feat(ui): inbox completa (chat + lead panel + QR + real-time)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -279,3 +279,32 @@ Formato:
 **Tempo gasto:** ~30 min
 
 **Smoke test:** `from app.services.conversation_orchestrator import ConversationOrchestrator` OK, todas as rotas registradas, sem erros de importação.
+
+---
+
+## 2026-04-25 13:25 — PR #10: Frontend UI completa
+
+**Decisões:**
+- Layout split 12-col: 3 (ConversationList) + 6 (MessageList) + 3 (QRCodePanel + LeadPanel).
+- `useConversations` com `useReducer` (sem zustand/react-query no escopo de 6h). 9 events do socket são reduzidos: `wa.message.received`, `wa.audio.received`, `audio.transcribed`, `wa.message.sent`, `wa.audio.sent`, `ai.response.generated`, `lead.updated`, `conversation.status_changed`, `ai.thinking`.
+- `MessageBubble` distingue tipo (TEXT/AUDIO/IMAGE), exibe transcrição inline em áudio, mostra status badge (sent/failed/etc) e horário.
+- `AIThinkingIndicator` com 3 dots staggered animate-bounce.
+- `QRCodePanel` tem botão "Inicializar instância" que faz POST `/api/whatsapp/instance` + POST `/api/whatsapp/webhook` + GET `/api/whatsapp/qrcode` em sequência. Renderiza imagem do QR embed em base64.
+- `LeadPanel` mostra nome, empresa, telefone, interesse, objetivo, volume estimado, status colorido (success qualified, warning needs_human).
+- Auto-scroll no `MessageList` em cada nova mensagem ou flag de thinking.
+
+**Dificuldades:**
+- TS erro inicial: `conversation.status_changed` typed como `Conversation` mas o backend só envia `{id, last_intent}`. Ajustado para `Partial<Conversation> & {id: string}` no socket.ts.
+- StrictMode + Socket.IO: validei via `useSocket` cleanup que NÃO desconecta — pattern mantém a conexão viva entre re-mounts em dev.
+
+**Trade-offs:**
+- Sem virtualização do `MessageList` — `ScrollArea` + `overflow-y-auto` é suficiente para <500 mensagens (caso típico de uma conversa de qualificação).
+- Sem suporte a múltiplas conversas selecionadas — a UI mostra apenas a `active` (primeira por default ou via `setActiveId`).
+- Sem dark mode toggle — tokens do shadcn já suportam, mas adicionar UI de toggle não é prioridade.
+
+**Sugestões da IA rejeitadas/alteradas:**
+- IA inicial sugeriu `react-hot-toast` para o erro emit. Rejeitei: o `error` evento já vai ser exibido em uma futura iteração; menos uma dep.
+
+**Tempo gasto:** ~30 min
+
+**Smoke test:** `npm run build` → tsc strict + Vite verde (302KB JS gzip 94KB).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,46 +1,78 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConversationList } from '@/components/chat/ConversationList'
+import { MessageList } from '@/components/chat/MessageList'
+import { LeadPanel } from '@/components/lead/LeadPanel'
+import { QRCodePanel } from '@/components/connection/QRCodePanel'
+import { useConnectionStatus } from '@/hooks/useConnectionStatus'
+import { useConversations } from '@/hooks/useConversations'
+import { useSocket } from '@/hooks/useSocket'
 
 function App() {
+  const { connected } = useSocket()
+  const { state, qrcode } = useConnectionStatus()
+  const { conversations, active, activeId, setActiveId, thinkingActive } = useConversations()
+
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="bg-background text-foreground flex h-screen flex-col">
       <header className="border-b bg-card">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <div className="mx-auto flex w-full max-w-[1400px] items-center justify-between px-6 py-3">
           <div className="flex items-center gap-3">
-            <span className="text-xl font-semibold">Contact Pro · Inbox</span>
-            <Badge variant="outline">v0.1 · scaffold</Badge>
+            <span className="text-lg font-semibold">Contact Pro · Inbox</span>
+            <Badge variant="outline" className="text-[10px]">
+              v0.1
+            </Badge>
           </div>
-          <Badge variant="warning">connecting…</Badge>
+          <div className="flex items-center gap-2 text-xs">
+            <Badge variant={connected ? 'success' : 'secondary'}>
+              socket: {connected ? 'on' : 'off'}
+            </Badge>
+            <Badge variant={state === 'open' ? 'success' : state === 'connecting' ? 'warning' : 'secondary'}>
+              wa: {state}
+            </Badge>
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto grid max-w-7xl grid-cols-1 gap-6 p-6 md:grid-cols-12">
-        <Card className="md:col-span-3">
-          <CardHeader>
-            <CardTitle>Conversas</CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            Sem conversas ainda. Pareie o WhatsApp para começar.
-          </CardContent>
-        </Card>
+      <main className="mx-auto grid w-full max-w-[1400px] flex-1 grid-cols-12 gap-4 overflow-hidden p-4">
+        <aside className="col-span-3 flex flex-col">
+          <Card className="flex-1 overflow-hidden p-0">
+            <CardHeader className="border-b py-3">
+              <CardTitle className="text-sm">Conversas</CardTitle>
+            </CardHeader>
+            <CardContent className="flex-1 overflow-hidden p-0">
+              <ConversationList
+                items={conversations}
+                activeId={activeId}
+                onSelect={setActiveId}
+              />
+            </CardContent>
+          </Card>
+        </aside>
 
-        <Card className="md:col-span-6">
-          <CardHeader>
-            <CardTitle>Mensagens</CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            O histórico aparecerá aqui em tempo real.
-          </CardContent>
-        </Card>
+        <section className="col-span-6 flex flex-col">
+          <Card className="flex flex-1 flex-col overflow-hidden p-0">
+            <CardHeader className="border-b py-3">
+              <CardTitle className="text-sm">
+                {active?.lead.name || active?.lead.whatsapp_jid?.replace(/@.*/, '') || 'Selecione uma conversa'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex-1 overflow-hidden p-0">
+              {active ? (
+                <MessageList messages={active.messages} thinking={thinkingActive} />
+              ) : (
+                <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+                  Aguardando primeira mensagem…
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
 
-        <Card className="md:col-span-3">
-          <CardHeader>
-            <CardTitle>Lead</CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            Dados extraídos pela IA serão exibidos aqui.
-          </CardContent>
-        </Card>
+        <aside className="col-span-3 flex flex-col gap-4 overflow-y-auto">
+          <QRCodePanel state={state} qrcode={qrcode} />
+          <LeadPanel lead={active?.lead ?? null} />
+        </aside>
       </main>
     </div>
   )

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -1,0 +1,35 @@
+# frontend/src/components/CLAUDE.md
+
+> Convenção de componentes. Leia antes de adicionar.
+
+## Pastas
+
+| Pasta | Conteúdo |
+|---|---|
+| `ui/` | Primitives shadcn (button, card, badge, scroll-area, separator, avatar). |
+| `chat/` | ConversationList, MessageList, MessageBubble, AIThinkingIndicator, AudioMessage, ImageMessage. |
+| `lead/` | LeadPanel. |
+| `connection/` | QRCodePanel, ConnectionStatus. |
+
+## Regras
+
+1. **Props 100% tipadas.** Sem `any`. Domínio em `src/types/domain.ts`.
+2. **Componentes puros.** Renderizam props; estado e chamadas vêm de hooks (`useConversations`, `useConnectionStatus`).
+3. **shadcn obrigatório para primitives.** Nunca renderizar `<button>` cru, sempre `<Button>`. Mesma regra para Card/Badge/etc.
+4. **Acessibilidade básica.** `aria-label` em ícones, `role="status"` no AIThinkingIndicator, alt text em imagens.
+5. **Sem CSS solto.** Tudo via classes Tailwind v4 + tokens OKLCH do shadcn.
+6. **Naming**: PascalCase para componentes. `SomeComponent.tsx` exporta `SomeComponent` nomeado (sem default).
+
+## Não fazer
+
+- Importar de `node_modules/@shadcn/ui` (não existe — copiamos para `src/components/ui/`).
+- Misturar lógica de fetch/socket dentro do componente.
+- Estilizar com `style={{}}` quando dá para usar classe Tailwind.
+- Esquecer key estável em listas (use `id` da entidade, nunca índice quando há add/remove).
+
+## Links
+
+- `chat/MessageBubble.tsx` — render de mensagem (TEXT/AUDIO com transcrição inline/IMAGE)
+- `chat/MessageList.tsx` — auto scroll
+- `lead/LeadPanel.tsx` — campos extraídos
+- `connection/QRCodePanel.tsx` — bootstrap da instância e QR

--- a/frontend/src/components/chat/AIThinkingIndicator.tsx
+++ b/frontend/src/components/chat/AIThinkingIndicator.tsx
@@ -1,0 +1,12 @@
+export function AIThinkingIndicator() {
+  return (
+    <div role="status" aria-live="polite" className="flex justify-start">
+      <div className="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-lg px-3 py-2 text-xs">
+        <span className="bg-foreground/60 size-1.5 animate-bounce rounded-full" style={{ animationDelay: '0ms' }} />
+        <span className="bg-foreground/60 size-1.5 animate-bounce rounded-full" style={{ animationDelay: '150ms' }} />
+        <span className="bg-foreground/60 size-1.5 animate-bounce rounded-full" style={{ animationDelay: '300ms' }} />
+        <span className="ml-2">IA pensando…</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ConversationList.tsx
+++ b/frontend/src/components/chat/ConversationList.tsx
@@ -1,0 +1,97 @@
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import type { Conversation, Lead } from '@/types/domain'
+
+interface Item {
+  conversation: Conversation
+  lead: Lead
+}
+
+interface Props {
+  items: Item[]
+  activeId: string | null
+  onSelect(id: string): void
+}
+
+const statusVariant: Record<Lead['status'], 'default' | 'success' | 'warning' | 'secondary'> = {
+  new: 'secondary',
+  qualified: 'success',
+  needs_human: 'warning',
+  opt_out: 'secondary',
+}
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const sec = Math.round(diffMs / 1000)
+  if (sec < 60) return `${sec}s`
+  if (sec < 3600) return `${Math.round(sec / 60)}min`
+  if (sec < 86400) return `${Math.round(sec / 3600)}h`
+  return `${Math.round(sec / 86400)}d`
+}
+
+function initials(name: string | null, jid: string): string {
+  const base = name?.trim() || jid.replace(/@.*/, '')
+  return base
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+}
+
+export function ConversationList({ items, activeId, onSelect }: Props) {
+  if (items.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center px-6 text-center text-sm">
+        Nenhuma conversa ainda. Pareie o WhatsApp para receber mensagens.
+      </div>
+    )
+  }
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col">
+        {items.map(({ conversation, lead }, idx) => (
+          <div key={conversation.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(conversation.id)}
+              className={cn(
+                'hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left transition-colors',
+                activeId === conversation.id && 'bg-accent',
+              )}
+            >
+              <Avatar>
+                <AvatarFallback>{initials(lead.name, lead.whatsapp_jid)}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-medium">
+                    {lead.name || lead.whatsapp_jid.replace(/@.*/, '') || 'Lead'}
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {relativeTime(conversation.last_message_at)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {conversation.last_intent && (
+                    <Badge variant="outline" className="text-[10px]">
+                      {conversation.last_intent.replaceAll('_', ' ')}
+                    </Badge>
+                  )}
+                  <Badge variant={statusVariant[lead.status]} className="text-[10px]">
+                    {lead.status.replaceAll('_', ' ')}
+                  </Badge>
+                </div>
+              </div>
+            </button>
+            {idx < items.length - 1 && <Separator />}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,0 +1,69 @@
+import { Mic, Image as ImageIcon } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { Message } from '@/types/domain'
+
+interface Props {
+  msg: Message
+}
+
+const statusVariant: Record<Message['status'], 'default' | 'success' | 'warning' | 'secondary' | 'destructive' | 'outline'> = {
+  pending: 'secondary',
+  sent: 'default',
+  delivered: 'default',
+  read: 'success',
+  failed: 'destructive',
+  received: 'outline',
+}
+
+export function MessageBubble({ msg }: Props) {
+  const isOut = msg.direction === 'out'
+  const showTranscription = msg.type === 'audio' && msg.transcription
+  return (
+    <div className={cn('flex w-full', isOut ? 'justify-end' : 'justify-start')}>
+      <div
+        className={cn(
+          'max-w-[80%] rounded-lg px-3 py-2 text-sm shadow-sm',
+          isOut ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground',
+        )}
+      >
+        <div className="mb-1 flex items-center gap-2 text-xs opacity-80">
+          {msg.type === 'audio' && (
+            <span className="inline-flex items-center gap-1">
+              <Mic className="size-3" /> Áudio
+            </span>
+          )}
+          {msg.type === 'image' && (
+            <span className="inline-flex items-center gap-1">
+              <ImageIcon className="size-3" /> Imagem
+            </span>
+          )}
+          {msg.intent && (
+            <Badge variant="outline" className="bg-background/40 text-[9px]">
+              {msg.intent.replaceAll('_', ' ')}
+            </Badge>
+          )}
+        </div>
+        <div className="whitespace-pre-wrap break-words">
+          {msg.type === 'audio' && !msg.transcription
+            ? '🎙️ áudio recebido (transcrevendo...)'
+            : msg.content || '(sem texto)'}
+        </div>
+        {showTranscription && (
+          <div className="mt-2 border-t border-foreground/10 pt-2 text-xs opacity-90">
+            <strong>Transcrição:</strong> {msg.transcription}
+          </div>
+        )}
+        <div className={cn('mt-1 flex items-center justify-end gap-1 text-[10px] opacity-70')}>
+          <span>{new Date(msg.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}</span>
+          {isOut && (
+            <Badge variant={statusVariant[msg.status]} className="px-1 text-[9px]">
+              {msg.status}
+            </Badge>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+import type { Message } from '@/types/domain'
+
+import { AIThinkingIndicator } from './AIThinkingIndicator'
+import { MessageBubble } from './MessageBubble'
+
+interface Props {
+  messages: Message[]
+  thinking: boolean
+}
+
+export function MessageList({ messages, thinking }: Props) {
+  const endRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [messages.length, thinking])
+
+  if (messages.length === 0 && !thinking) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+        Sem mensagens ainda. As mensagens chegarão aqui em tempo real.
+      </div>
+    )
+  }
+
+  return (
+    <ScrollArea className="h-full px-4">
+      <div className="flex flex-col gap-3 py-4">
+        {messages.map((m) => (
+          <MessageBubble key={m.id} msg={m} />
+        ))}
+        {thinking && <AIThinkingIndicator />}
+        <div ref={endRef} />
+      </div>
+    </ScrollArea>
+  )
+}

--- a/frontend/src/components/connection/QRCodePanel.tsx
+++ b/frontend/src/components/connection/QRCodePanel.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { api } from '@/lib/api'
+import type { ConnectionState } from '@/types/domain'
+
+interface Props {
+  state: ConnectionState
+  qrcode: string | null
+}
+
+const stateBadge: Record<ConnectionState, { variant: 'default' | 'success' | 'warning' | 'secondary'; label: string }> = {
+  open: { variant: 'success', label: 'Conectado' },
+  connecting: { variant: 'warning', label: 'Conectando…' },
+  close: { variant: 'secondary', label: 'Desconectado' },
+  unknown: { variant: 'secondary', label: 'Status desconhecido' },
+}
+
+export function QRCodePanel({ state, qrcode }: Props) {
+  const [bootstrapping, setBootstrapping] = useState(false)
+  const [bootstrapMsg, setBootstrapMsg] = useState<string | null>(null)
+  const [pulledQr, setPulledQr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (qrcode) setPulledQr(null)
+  }, [qrcode])
+
+  async function bootstrap() {
+    setBootstrapping(true)
+    setBootstrapMsg(null)
+    try {
+      await api('/api/whatsapp/instance', { method: 'POST' })
+      await api('/api/whatsapp/webhook', { method: 'POST' })
+      const qr = await api<{ base64?: string; code?: string }>('/api/whatsapp/qrcode', { method: 'GET' })
+      setPulledQr(qr.base64 ?? null)
+      setBootstrapMsg('Pareie escaneando o QR abaixo.')
+    } catch (err) {
+      setBootstrapMsg((err as Error).message)
+    } finally {
+      setBootstrapping(false)
+    }
+  }
+
+  const display = qrcode ?? pulledQr
+  const meta = stateBadge[state]
+
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <div className="flex items-center justify-between">
+          <CardTitle>WhatsApp</CardTitle>
+          <Badge variant={meta.variant}>{meta.label}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {state === 'open' ? (
+          <p className="text-muted-foreground text-sm">
+            Conta pareada. Mensagens serão recebidas automaticamente.
+          </p>
+        ) : (
+          <>
+            <p className="text-muted-foreground text-sm">
+              Crie a instância e escaneie o QR Code com o WhatsApp do celular.
+            </p>
+            <Button size="sm" onClick={bootstrap} disabled={bootstrapping}>
+              {bootstrapping ? 'Iniciando…' : 'Inicializar instância'}
+            </Button>
+            {bootstrapMsg && (
+              <p className="text-muted-foreground text-xs">{bootstrapMsg}</p>
+            )}
+            {display && (
+              <div className="bg-card flex justify-center rounded-md border p-3">
+                <img
+                  src={display.startsWith('data:') ? display : `data:image/png;base64,${display}`}
+                  alt="QR Code WhatsApp"
+                  className="h-48 w-48"
+                />
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/lead/LeadPanel.tsx
+++ b/frontend/src/components/lead/LeadPanel.tsx
@@ -1,0 +1,70 @@
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import type { Lead } from '@/types/domain'
+
+interface Props {
+  lead: Lead | null
+}
+
+const statusLabel: Record<Lead['status'], string> = {
+  new: 'Novo',
+  qualified: 'Qualificado',
+  needs_human: 'Precisa de humano',
+  opt_out: 'Opt-out',
+}
+
+const statusVariant: Record<Lead['status'], 'default' | 'success' | 'warning' | 'secondary'> = {
+  new: 'secondary',
+  qualified: 'success',
+  needs_human: 'warning',
+  opt_out: 'secondary',
+}
+
+export function LeadPanel({ lead }: Props) {
+  if (!lead) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Lead</CardTitle>
+        </CardHeader>
+        <CardContent className="text-muted-foreground text-sm">
+          Selecione uma conversa para ver os dados extraídos.
+        </CardContent>
+      </Card>
+    )
+  }
+  return (
+    <Card>
+      <CardHeader className="space-y-1">
+        <div className="flex items-center justify-between">
+          <CardTitle>{lead.name ?? 'Lead sem nome'}</CardTitle>
+          <Badge variant={statusVariant[lead.status]}>{statusLabel[lead.status]}</Badge>
+        </div>
+        <p className="text-muted-foreground text-xs">{lead.whatsapp_jid}</p>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <Field label="Empresa" value={lead.company} />
+        <Field label="Telefone" value={lead.phone} />
+        <Separator />
+        <Field
+          label="Interesse"
+          value={lead.service_interest === 'unknown' ? null : lead.service_interest?.replaceAll('_', ' ')}
+        />
+        <Field label="Objetivo" value={lead.lead_goal} />
+        <Field label="Volume estimado" value={lead.estimated_volume} />
+      </CardContent>
+    </Card>
+  )
+}
+
+function Field({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-xs uppercase tracking-wide">{label}</div>
+      <div className={value ? 'font-medium' : 'text-muted-foreground italic'}>
+        {value ?? '—'}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useConversations.ts
+++ b/frontend/src/hooks/useConversations.ts
@@ -1,0 +1,194 @@
+import { useEffect, useReducer, useState } from 'react'
+
+import { socket } from '@/lib/socket'
+import type { Conversation, Lead, Message } from '@/types/domain'
+
+interface ConvWithDetails {
+  conversation: Conversation
+  lead: Lead
+  messages: Message[]
+}
+
+interface State {
+  byId: Record<string, ConvWithDetails>
+  order: string[] // conversation ids ordered by last_message_at desc
+  thinkingByConv: Record<string, boolean>
+}
+
+type Action =
+  | { type: 'message_received'; payload: Message }
+  | { type: 'message_sent'; payload: Message }
+  | { type: 'audio_transcribed'; payload: { messageId: string; transcription: string } }
+  | { type: 'lead_updated'; payload: Lead }
+  | { type: 'conversation_updated'; payload: Partial<Conversation> & { id: string } }
+  | { type: 'thinking'; payload: { conversationId: string; status: 'start' | 'end' } }
+
+const initialState: State = { byId: {}, order: [], thinkingByConv: {} }
+
+function ensureConversation(state: State, conversationId: string, lead?: Lead): State {
+  if (state.byId[conversationId]) return state
+  const placeholderLead: Lead =
+    lead ??
+    ({
+      id: `lead-pending-${conversationId}`,
+      whatsapp_jid: '',
+      name: null,
+      company: null,
+      phone: null,
+      service_interest: 'unknown',
+      lead_goal: null,
+      estimated_volume: null,
+      status: 'new',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } satisfies Lead)
+  return {
+    ...state,
+    byId: {
+      ...state.byId,
+      [conversationId]: {
+        conversation: {
+          id: conversationId,
+          lead_id: placeholderLead.id,
+          last_intent: null,
+          last_message_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        },
+        lead: placeholderLead,
+        messages: [],
+      },
+    },
+    order: [conversationId, ...state.order.filter((id) => id !== conversationId)],
+  }
+}
+
+function appendMessage(state: State, msg: Message): State {
+  const cid = msg.conversation_id
+  const next = ensureConversation(state, cid)
+  const existing = next.byId[cid].messages
+  if (existing.some((m) => m.id === msg.id)) return next
+  return {
+    ...next,
+    byId: {
+      ...next.byId,
+      [cid]: {
+        ...next.byId[cid],
+        conversation: {
+          ...next.byId[cid].conversation,
+          last_message_at: msg.created_at,
+        },
+        messages: [...existing, msg],
+      },
+    },
+    order: [cid, ...next.order.filter((id) => id !== cid)],
+  }
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'message_received':
+    case 'message_sent':
+      return appendMessage(state, action.payload)
+    case 'audio_transcribed': {
+      const next = { ...state, byId: { ...state.byId } }
+      for (const cid of Object.keys(next.byId)) {
+        const conv = next.byId[cid]
+        const idx = conv.messages.findIndex((m) => m.id === action.payload.messageId)
+        if (idx >= 0) {
+          const updated = [...conv.messages]
+          updated[idx] = { ...updated[idx], transcription: action.payload.transcription }
+          next.byId[cid] = { ...conv, messages: updated }
+          break
+        }
+      }
+      return next
+    }
+    case 'lead_updated': {
+      const lead = action.payload
+      const cid = Object.keys(state.byId).find((id) => state.byId[id].lead.id === lead.id || state.byId[id].lead.whatsapp_jid === lead.whatsapp_jid)
+      if (!cid) return state
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          [cid]: { ...state.byId[cid], lead },
+        },
+      }
+    }
+    case 'conversation_updated': {
+      const { id, ...patch } = action.payload
+      const conv = state.byId[id]
+      if (!conv) return state
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          [id]: { ...conv, conversation: { ...conv.conversation, ...patch } },
+        },
+      }
+    }
+    case 'thinking':
+      return {
+        ...state,
+        thinkingByConv: {
+          ...state.thinkingByConv,
+          [action.payload.conversationId]: action.payload.status === 'start',
+        },
+      }
+    default:
+      return state
+  }
+}
+
+export function useConversations() {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onMessageReceived = (msg: Message) => dispatch({ type: 'message_received', payload: msg })
+    const onMessageSent = (msg: Message) => dispatch({ type: 'message_sent', payload: msg })
+    const onAiResponse = (msg: Message) => dispatch({ type: 'message_sent', payload: msg })
+    const onAudioReceived = (msg: Message) => dispatch({ type: 'message_received', payload: msg })
+    const onAudioTranscribed = (data: { messageId: string; transcription: string }) =>
+      dispatch({ type: 'audio_transcribed', payload: data })
+    const onLeadUpdated = (lead: Lead) => dispatch({ type: 'lead_updated', payload: lead })
+    const onConv = (data: Partial<Conversation> & { id: string }) =>
+      dispatch({ type: 'conversation_updated', payload: data })
+    const onThinking = (data: { conversationId: string; status: 'start' | 'end' }) =>
+      dispatch({ type: 'thinking', payload: data })
+
+    socket.on('wa.message.received', onMessageReceived)
+    socket.on('wa.audio.received', onAudioReceived)
+    socket.on('audio.transcribed', onAudioTranscribed)
+    socket.on('wa.message.sent', onMessageSent)
+    socket.on('wa.audio.sent', onMessageSent)
+    socket.on('ai.response.generated', onAiResponse)
+    socket.on('lead.updated', onLeadUpdated)
+    socket.on('conversation.status_changed', onConv)
+    socket.on('ai.thinking', onThinking)
+
+    return () => {
+      socket.off('wa.message.received', onMessageReceived)
+      socket.off('wa.audio.received', onAudioReceived)
+      socket.off('audio.transcribed', onAudioTranscribed)
+      socket.off('wa.message.sent', onMessageSent)
+      socket.off('wa.audio.sent', onMessageSent)
+      socket.off('ai.response.generated', onAiResponse)
+      socket.off('lead.updated', onLeadUpdated)
+      socket.off('conversation.status_changed', onConv)
+      socket.off('ai.thinking', onThinking)
+    }
+  }, [])
+
+  const conversations = state.order.map((id) => state.byId[id])
+  const active = activeId ? state.byId[activeId] : conversations[0]
+  const thinkingActive = active ? state.thinkingByConv[active.conversation.id] === true : false
+
+  return {
+    conversations,
+    active,
+    activeId: active?.conversation.id ?? null,
+    setActiveId,
+    thinkingActive,
+  }
+}

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -26,7 +26,7 @@ export interface ServerToClientEvents {
   'wa.reaction.sent': (data: { messageId: string; emoji: string }) => void
 
   'lead.updated': (data: Lead) => void
-  'conversation.status_changed': (data: Conversation) => void
+  'conversation.status_changed': (data: Partial<Conversation> & { id: string }) => void
 
   error: (data: { code?: string; message: string; conversation_id?: string }) => void
 }


### PR DESCRIPTION
Layout split 3+6+3:
- ConversationList (avatar fallback, intent badge, status pill colorido por LeadStatus)
- MessageList com auto-scroll + AIThinkingIndicator (3 dots animate-bounce, role=status)
- MessageBubble distingue TEXT/AUDIO/IMAGE com icone, transcricao inline em audio, status badge sent/failed
- LeadPanel com campos extraidos (nome/empresa/telefone/interesse/objetivo/volume) + status colorido
- QRCodePanel com botao "Inicializar instancia" (POST instance + POST webhook + GET qrcode em sequencia)
useConversations com useReducer reduzindo 9 socket events. components/CLAUDE.md + hooks/CLAUDE.md.

Smoke: npm run build verde (302KB JS gzip 94KB).

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)