### PR TITLE
feat(audio): receive audio + Whisper STT + transcription in UI

### DIFF
--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -40,6 +40,7 @@ from app.models.message import Message
 from app.services.ai.base import AIProvider, AIResponse, ChatTurn
 from app.services.ai.factory import get_ai_provider
 from app.services.ai.prompts import build_system_prompt
+from app.services.transcription.openai_stt import OpenAITranscriber, get_transcriber
 from app.services.whatsapp.evolution_client import (
     EvolutionAPIError,
     EvolutionClient,
@@ -96,10 +97,12 @@ class ConversationOrchestrator:
         session: AsyncSession,
         ai: AIProvider | None = None,
         whatsapp: EvolutionClient | None = None,
+        transcriber: OpenAITranscriber | None = None,
     ) -> None:
         self.session = session
         self.ai = ai or get_ai_provider()
         self.whatsapp = whatsapp or get_evolution_client()
+        self.transcriber = transcriber or get_transcriber()
 
     # ----- repository helpers (inline para 6h) -----
 
@@ -209,8 +212,25 @@ class ConversationOrchestrator:
         except EvolutionAPIError as exc:
             logger.warning("reaction_failed", extra={"error": str(exc)})
 
-        # 5. (texto only por enquanto — STT/Vision nos PRs seguintes)
-        ai_input_text = parsed.text or "[mensagem sem texto]"
+        # 5. áudio → STT (Whisper); imagem → vision (PR #14)
+        ai_input_text = parsed.text or ""
+        if parsed.message_type == MessageType.AUDIO:
+            transcription = await self._transcribe_audio(parsed)
+            if transcription:
+                msg_in.transcription = transcription
+                self.session.add(msg_in)
+                await self.session.commit()
+                await self.session.refresh(msg_in)
+                await emit_to_conversation(
+                    str(conv.id),
+                    "audio.transcribed",
+                    {"messageId": str(msg_in.id), "transcription": transcription},
+                )
+                ai_input_text = transcription
+            else:
+                ai_input_text = "[áudio recebido sem transcrição disponível]"
+        if not ai_input_text:
+            ai_input_text = "[mensagem sem texto]"
 
         # 6. AI thinking + chamada
         await emit_to_conversation(
@@ -320,6 +340,39 @@ class ConversationOrchestrator:
         await self._send_smart_reaction(parsed, self._reaction_for_status(lead.status))
 
     # ----- helpers -----
+
+    async def _transcribe_audio(self, parsed: ParsedMessage) -> str:
+        """Baixa o áudio (se ainda não veio em base64) e transcreve via Whisper."""
+        import base64
+
+        b64 = parsed.media_base64
+        mime = parsed.media_mime
+        if not b64:
+            try:
+                media = await self.whatsapp.download_media_base64(
+                    {
+                        "id": parsed.whatsapp_message_id,
+                        "remoteJid": parsed.remote_jid,
+                        "fromMe": False,
+                    }
+                )
+            except EvolutionAPIError as exc:
+                logger.warning("audio_download_failed", extra={"error": str(exc)})
+                return ""
+            b64 = media.get("base64")
+            mime = media.get("mimetype") or mime or "audio/ogg"
+        if not b64:
+            return ""
+        try:
+            audio_bytes = base64.b64decode(b64)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("audio_decode_failed", extra={"error": str(exc)})
+            return ""
+        try:
+            return await self.transcriber.transcribe(audio_bytes=audio_bytes, mime_type=mime)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("stt_pipeline_failed", extra={"error": str(exc)})
+            return ""
 
     @staticmethod
     def _reaction_for_status(status: LeadStatus) -> str:

--- a/backend/app/services/transcription/CLAUDE.md
+++ b/backend/app/services/transcription/CLAUDE.md
@@ -1,0 +1,29 @@
+# app/services/transcription/CLAUDE.md
+
+> STT (speech-to-text) — transcrição de áudio recebido.
+
+## Provider atual
+
+OpenAI Whisper (`whisper-1`) via `client.audio.transcriptions.create`.
+
+- Aceita: ogg, opus, m4a, mp3, mp4, mpga, mpeg, wav, webm.
+- Limite: **25 MB**.
+- WhatsApp PTT chega como `audio/ogg; codecs=opus` — Whisper aceita direto.
+- Default `language="pt"` para reduzir alucinação.
+
+## Como adicionar outro provider (Groq Whisper, Deepgram, Google)
+
+1. Criar `app/services/transcription/<nome>_stt.py` com método `transcribe(audio_bytes, mime_type, filename_hint, language)` retornando `str`.
+2. Adicionar option em `Settings.stt_provider`.
+3. Atualizar este CLAUDE.md.
+
+## Não fazer
+
+- Logar `audio_bytes` (binário grande).
+- Passar mime sem extensão correta no filename — Whisper rejeita.
+- Esquecer de validar tamanho (>25 MB → erro 413 da OpenAI).
+
+## Links
+
+- `openai_stt.py` — transcriber
+- Plano: `/Users/gasparellodev/.claude/plans/o-seu-papel-crystalline-lantern.md`

--- a/backend/app/services/transcription/openai_stt.py
+++ b/backend/app/services/transcription/openai_stt.py
@@ -1,0 +1,66 @@
+"""STT via OpenAI Whisper."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from openai import AsyncOpenAI
+
+from app.core.config import Settings, get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAITranscriber:
+    name = "openai"
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.model = self.settings.stt_model
+        self.client = AsyncOpenAI(api_key=self.settings.active_stt_api_key)
+
+    async def transcribe(
+        self,
+        *,
+        audio_bytes: bytes,
+        mime_type: str | None = None,
+        filename_hint: str = "audio.ogg",
+        language: str | None = "pt",
+    ) -> str:
+        """Whisper aceita ogg/opus, m4a, mp3, wav. Limite 25 MB.
+
+        WhatsApp PTT é ogg/opus por padrão.
+        """
+        # OpenAI lib espera arquivo-like com nome (extensão) — passa mime via filename
+        ext = "ogg"
+        if mime_type and "/" in mime_type:
+            ext = mime_type.split("/", 1)[1].split(";")[0].strip()
+            ext = {"mpeg": "mp3", "x-m4a": "m4a"}.get(ext, ext)
+        filename = filename_hint if "." in filename_hint else f"audio.{ext}"
+
+        buf = io.BytesIO(audio_bytes)
+        buf.name = filename
+
+        kwargs: dict = {"model": self.model, "file": buf}
+        if language:
+            kwargs["language"] = language
+
+        try:
+            resp = await self.client.audio.transcriptions.create(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("stt_failed", extra={"model": self.model, "error": str(exc)})
+            raise
+
+        text = getattr(resp, "text", None) or ""
+        return text.strip()
+
+
+_singleton: OpenAITranscriber | None = None
+
+
+def get_transcriber() -> OpenAITranscriber:
+    global _singleton
+    if _singleton is None:
+        _singleton = OpenAITranscriber()
+    return _singleton


### PR DESCRIPTION
OpenAITranscriber via client.audio.transcriptions.create (whisper-1, language=pt). Aceita ogg/opus/m4a/mp3/wav, limite 25MB.
Orchestrator: download base64 (do payload se webhook.base64=true ou via getBase64FromMediaMessage) -> decodifica -> transcribe -> grava em msg_in.transcription -> emit audio.transcribed -> substitui ai_input_text. Falha de download/decode/STT loga mas nao quebra (fallback "[audio recebido sem transcricao]").
transcription/CLAUDE.md.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)