### PR TITLE
feat(vision): incoming images via multimodal

### DIFF
--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -42,6 +42,7 @@ from app.services.ai.factory import get_ai_provider
 from app.services.ai.prompts import build_system_prompt
 from app.services.transcription.openai_stt import OpenAITranscriber, get_transcriber
 from app.services.tts.openai_tts import OpenAITTS, get_tts
+from app.services.vision.multimodal import describe_image as describe_image_async
 from app.services.whatsapp.evolution_client import (
     EvolutionAPIError,
     EvolutionClient,
@@ -215,9 +216,28 @@ class ConversationOrchestrator:
         except EvolutionAPIError as exc:
             logger.warning("reaction_failed", extra={"error": str(exc)})
 
-        # 5. áudio → STT (Whisper); imagem → vision (PR #14)
+        # 5. áudio → STT; imagem → vision (multimodal)
         ai_input_text = parsed.text or ""
-        if parsed.message_type == MessageType.AUDIO:
+        if parsed.message_type == MessageType.IMAGE:
+            description = await self._describe_image(parsed)
+            if description:
+                msg_in.transcription = description
+                self.session.add(msg_in)
+                await self.session.commit()
+                await self.session.refresh(msg_in)
+                await emit_to_conversation(
+                    str(conv.id),
+                    "audio.transcribed",
+                    {"messageId": str(msg_in.id), "transcription": description},
+                )
+                caption = parsed.text or ""
+                ai_input_text = (
+                    f"[Lead enviou imagem. Descrição: {description}]"
+                    + (f"\nLegenda: {caption}" if caption else "")
+                )
+            else:
+                ai_input_text = "[imagem recebida — descrição indisponível]"
+        elif parsed.message_type == MessageType.AUDIO:
             transcription = await self._transcribe_audio(parsed)
             if transcription:
                 msg_in.transcription = transcription
@@ -362,6 +382,39 @@ class ConversationOrchestrator:
         await self._send_smart_reaction(parsed, self._reaction_for_status(lead.status))
 
     # ----- helpers -----
+
+    async def _describe_image(self, parsed: ParsedMessage) -> str:
+        import base64
+
+        b64 = parsed.media_base64
+        mime = parsed.media_mime or "image/jpeg"
+        if not b64:
+            try:
+                media = await self.whatsapp.download_media_base64(
+                    {
+                        "id": parsed.whatsapp_message_id,
+                        "remoteJid": parsed.remote_jid,
+                        "fromMe": False,
+                    }
+                )
+            except EvolutionAPIError as exc:
+                logger.warning("image_download_failed", extra={"error": str(exc)})
+                return ""
+            b64 = media.get("base64")
+            mime = media.get("mimetype") or mime
+        if not b64:
+            return ""
+        try:
+            image_bytes = base64.b64decode(b64)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("image_decode_failed", extra={"error": str(exc)})
+            return ""
+        return await describe_image_async(
+            image_bytes=image_bytes,
+            mime_type=mime,
+            hint=parsed.text or "",
+            provider=self.ai,
+        )
 
     async def _send_audio_reply(self, *, parsed: ParsedMessage, reply_text: str) -> dict:
         """Gera TTS e envia como PTT via Evolution. Retorna a resposta crua do Evolution."""

--- a/backend/app/services/vision/CLAUDE.md
+++ b/backend/app/services/vision/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/services/vision/CLAUDE.md
+
+> Vision (descrição de imagem para o pipeline de texto).
+
+## Provider atual
+
+Usa o mesmo `AIProvider` ativo (`get_ai_provider()`) — `describe_image` em OpenAI e Anthropic.
+
+- OpenAI: `chat.completions.create` com `image_url` data URL.
+- Anthropic: `messages.create` com `{type: image, source: base64}`.
+
+## Limites
+
+- ~4 MB de bytes brutos (~3 MB em base64). Anthropic recusa imagens maiores. OpenAI aguenta um pouco mais.
+- Imagens muito grandes podem ser redimensionadas com PIL (não implementado neste PR de 6h).
+
+## Como integra ao orchestrator
+
+Quando `parsed.message_type == IMAGE`:
+1. download base64 (já vem ou via `getBase64FromMediaMessage`)
+2. `describe_image(image_bytes, mime_type, hint=parsed.text)` retorna descrição em PT
+3. orchestrator alimenta `ai_input_text = "[imagem] {description}\nLegenda: {parsed.text}"`
+
+## Não fazer
+
+- Logar a imagem em base64 (estourar log).
+- Aceitar mime fora de `image/jpeg|png|webp|gif` (Anthropic recusa outros).
+- Esquecer de checar tamanho — provider rejeita mas custo de banda já foi.
+
+## Links
+
+- `multimodal.py` — wrapper simples
+- `services/ai/{openai,anthropic}_provider.py:describe_image`
+- Plano: `/Users/gasparellodev/.claude/plans/o-seu-papel-crystalline-lantern.md`

--- a/backend/app/services/vision/multimodal.py
+++ b/backend/app/services/vision/multimodal.py
@@ -1,0 +1,35 @@
+"""Wrapper sobre o AIProvider.describe_image — adapta inputs do orchestrator."""
+
+from __future__ import annotations
+
+import logging
+
+from app.services.ai.base import AIProvider
+from app.services.ai.factory import get_ai_provider
+
+logger = logging.getLogger(__name__)
+
+MAX_IMAGE_BYTES = 4 * 1024 * 1024  # ~4MB → ~3MB em base64; Anthropic limit ~3.75MB
+
+
+async def describe_image(
+    *,
+    image_bytes: bytes,
+    mime_type: str,
+    hint: str = "",
+    provider: AIProvider | None = None,
+) -> str:
+    if len(image_bytes) > MAX_IMAGE_BYTES:
+        logger.warning("vision_image_too_large", extra={"size": len(image_bytes)})
+        return "[imagem muito grande para descrição]"
+    import base64
+
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+    prov = provider or get_ai_provider()
+    try:
+        return await prov.describe_image(
+            image_base64=image_b64, mime_type=mime_type, hint=hint
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("vision_describe_failed", extra={"error": str(exc)})
+        return ""


### PR DESCRIPTION
services/vision/multimodal.py:describe_image chama o AIProvider ativo (mesmo OpenAI ou Anthropic). Limite ~4MB para evitar rejeicao do provider (Anthropic ~3.75MB base64).
Orchestrator: detecta MessageType.IMAGE -> baixa media (base64 do payload ou via getBase64FromMediaMessage) -> describe_image -> grava como msg_in.transcription -> emit audio.transcribed (mesmo evento — UI mostra inline) -> compoe ai_input_text com "[Lead enviou imagem. Descricao: ...]\nLegenda: ...".
Reusa o AIProvider configurado por AI_PROVIDER.
vision/CLAUDE.md.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)