### PR TITLE
fix: critical security and idempotency from review (Closes #31 #32 #34)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -357,3 +357,15 @@ LeadPanel + status pills + intent badges já estavam no PR #10. Marcado completo
 **Tempo:** ~25 min.
 
 **Smoke test final:** `docker compose config --quiet` ✓; `cd backend && uv run python -c "from app.main import app"` ✓; `cd frontend && npm run build` ✓.
+
+---
+
+## 2026-04-25 14:50 — PR de follow-up A: críticos do security review (#31, #32) + body cap (#34)
+
+**Decisões:**
+- **#31** (apikey bypassável): header obrigatório; `hmac.compare_digest` para timing-safe; sem chave configurada → 503.
+- **#32** (race em idempotência): `try/except IntegrityError` no commit da Message IN; duplicata silenciosa via UNIQUE.
+- **#34** (body cap): guard de Content-Length 25 MB → 413 quando excede.
+- Bonus: response do orchestrator não vaza `str(exc)`; helper `_mask_jid` para PII em logs.
+
+**Tempo:** ~15 min.

--- a/backend/app/api/routes/webhooks.py
+++ b/backend/app/api/routes/webhooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 from typing import Any
 
@@ -12,6 +13,22 @@ from app.core.socketio import emit_global
 from app.db.session import SessionLocal
 from app.services.conversation_orchestrator import ConversationOrchestrator
 from app.services.whatsapp.payload import normalize_event, parse_messages_upsert
+
+# Limite de tamanho do body do webhook (~25 MB — alinhado com STT do Whisper).
+# Áudio/imagem em base64 (webhook.base64=true) chegam embutidos no payload.
+MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024
+
+
+def _mask_jid(jid: str | None) -> str:
+    """Mascara o número telefônico no JID para reduzir PII em logs."""
+    if not jid:
+        return "<empty>"
+    local = jid.split("@", 1)[0]
+    if len(local) <= 4:
+        return f"****@{jid.split('@', 1)[1]}" if "@" in jid else "****"
+    masked = f"{local[:2]}****{local[-2:]}"
+    suffix = jid.split("@", 1)[1] if "@" in jid else ""
+    return f"{masked}@{suffix}" if suffix else masked
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
@@ -31,8 +48,20 @@ async def evolution_webhook(
     """
     settings = get_settings()
 
-    if x_apikey and settings.evolution_api_key and x_apikey != settings.evolution_api_key:
+    # Auth obrigatória (#31). Comparação timing-safe via hmac.compare_digest.
+    expected = settings.evolution_api_key
+    if not expected:
+        # Sem chave configurada: rejeita por segurança em vez de aceitar tudo.
+        logger.error("webhook_apikey_not_configured")
+        raise HTTPException(status_code=503, detail="webhook not configured")
+    if not x_apikey or not hmac.compare_digest(x_apikey, expected):
         raise HTTPException(status_code=401, detail="invalid apikey")
+
+    # Cap de tamanho do body (#34). Confiar no Content-Length quando presente;
+    # caso ausente (chunked), continuar — Starlette/uvicorn já tem limite default.
+    content_length = request.headers.get("content-length")
+    if content_length and content_length.isdigit() and int(content_length) > MAX_WEBHOOK_BODY_BYTES:
+        raise HTTPException(status_code=413, detail="payload too large")
 
     try:
         payload = await request.json()
@@ -55,13 +84,21 @@ async def evolution_webhook(
             try:
                 await orchestrator.handle_incoming(parsed)
             except Exception as exc:  # noqa: BLE001
-                logger.exception("orchestrator_failed", extra={"error": str(exc)})
+                # Loga full exc internamente; resposta ao Evolution é genérica para não
+                # vazar stack/SQL hints (achado [Médio] do security review).
+                logger.exception(
+                    "orchestrator_failed",
+                    extra={
+                        "error_class": exc.__class__.__name__,
+                        "remote_jid": _mask_jid(parsed.remote_jid),
+                    },
+                )
                 await emit_global(
                     "error",
-                    {"code": "orchestrator_failed", "message": str(exc)},
+                    {"code": "orchestrator_failed", "message": "internal_error"},
                 )
                 # Devolver 200 para Evolution não fazer redelivery infinita.
-                return {"status": "error", "detail": str(exc)[:200]}
+                return {"status": "error"}
         return {"status": "processed", "id": parsed.whatsapp_message_id}
 
     if event in {"connection.update"}:

--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.socketio import emit_global, emit_to_conversation
@@ -183,7 +184,10 @@ class ConversationOrchestrator:
         lead = await self._upsert_lead(jid=parsed.remote_jid, push_name=parsed.push_name)
         conv = await self._upsert_conversation(lead)
 
-        # 3. persist IN
+        # 3. persist IN — protege contra race entre `_exists_message` e o INSERT.
+        # Dois webhooks concorrentes podem passar pelo check; o segundo levanta
+        # IntegrityError no UNIQUE de whatsapp_message_id e tratamos como duplicata
+        # silenciosa (mesma semântica do passo 1). Issue #32.
         msg_in = Message(
             conversation_id=conv.id,
             whatsapp_message_id=parsed.whatsapp_message_id,
@@ -194,7 +198,15 @@ class ConversationOrchestrator:
             status=MessageStatus.RECEIVED,
         )
         self.session.add(msg_in)
-        await self.session.commit()
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            logger.info(
+                "orchestrator_duplicate_race",
+                extra={"id": parsed.whatsapp_message_id},
+            )
+            return
         await self.session.refresh(msg_in)
         await emit_to_conversation(
             str(conv.id), "wa.message.received", _msg_to_dict(msg_in)


### PR DESCRIPTION
## Descrição

Endurece o webhook contra forge/DoS e fecha race condition na idempotência. Bonus: limita PII em log e remove vazamento de stack trace.

## Tipo

- [x] fix

## Conteúdo

### #31 — webhook apikey bypassable (Crítico)
\`backend/app/api/routes/webhooks.py\`:
- header \`apikey\` agora **obrigatório** (era opcional quando ausente)
- comparação via \`hmac.compare_digest\` (timing-safe)
- sem chave configurada → 503 (rejeita por segurança em vez de aceitar tudo)

### #32 — race em \`_exists_message\` (Crítico)
\`backend/app/services/conversation_orchestrator.py\`:
- \`try/except IntegrityError\` no commit da Message IN — defesa em profundidade ao check-then-insert
- duplicata silenciosa via UNIQUE constraint do banco
- log estruturado em \`orchestrator_duplicate_race\`

### #34 — body cap (Alto)
\`backend/app/api/routes/webhooks.py\`:
- guard de Content-Length 25 MB → HTTP 413 quando excede

### Bônus (achados [Médio] do mesmo review)
- response do orchestrator não vaza \`str(exc)\` (apenas \`error_class\` internamente)
- helper \`_mask_jid\` mascara PII em logs (\`5511999999999\` → \`55****99\`)

## Checklist

- [x] CLAUDE.md afetado: nenhum (mudanças não alteram contratos)
- [x] DEVELOPMENT_LOG.md atualizado
- [x] Conventional Commits + Closes #N
- [x] Smoke test: \`uv run python -c "from app.main import app"\` ✓ + assert do \`_mask_jid\` ✓

Closes #31
Closes #32
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)