### PR TITLE
fix(whatsapp): require admin token on /api/whatsapp/* (Closes #33)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,9 @@ APP_PORT=8000
 FRONTEND_PORT=5173
 LOG_LEVEL=INFO
 SOCKET_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# ===== Admin auth (rotas /api/whatsapp/*) =====
+# Token obrigatório para acionar setup da instância e ler QR Code.
+# Frontend recebe via VITE_ADMIN_TOKEN (build-time) e envia em X-Admin-Token.
+ADMIN_API_TOKEN=change-me-admin-token
+VITE_ADMIN_TOKEN=change-me-admin-token

--- a/backend/app/api/routes/whatsapp.py
+++ b/backend/app/api/routes/whatsapp.py
@@ -6,11 +6,17 @@ da instância na primeira execução. As chamadas são proxy para o Evolution.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from app.api.security import require_admin_token
 from app.services.whatsapp.evolution_client import EvolutionAPIError, get_evolution_client
 
-router = APIRouter(prefix="/api/whatsapp", tags=["whatsapp"])
+# Todas as rotas exigem `X-Admin-Token` (issue #33). Vazio em settings = 503.
+router = APIRouter(
+    prefix="/api/whatsapp",
+    tags=["whatsapp"],
+    dependencies=[Depends(require_admin_token)],
+)
 
 
 @router.post("/instance")
@@ -31,7 +37,13 @@ async def get_qrcode() -> dict:
     try:
         return await client.connect()
     except EvolutionAPIError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        # Não vaza str(exc) (URLs internas / hints SQL); detalhe completo vai para o log.
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "evolution_proxy_error", extra={"error_class": exc.__class__.__name__}
+        )
+        raise HTTPException(status_code=502, detail="evolution unreachable") from exc
 
 
 @router.get("/connection")
@@ -40,7 +52,13 @@ async def get_connection_state() -> dict:
     try:
         return await client.connection_state()
     except EvolutionAPIError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        # Não vaza str(exc) (URLs internas / hints SQL); detalhe completo vai para o log.
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "evolution_proxy_error", extra={"error_class": exc.__class__.__name__}
+        )
+        raise HTTPException(status_code=502, detail="evolution unreachable") from exc
 
 
 @router.post("/webhook")
@@ -56,4 +74,10 @@ async def setup_webhook() -> dict:
             base64=True,
         )
     except EvolutionAPIError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        # Não vaza str(exc) (URLs internas / hints SQL); detalhe completo vai para o log.
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "evolution_proxy_error", extra={"error_class": exc.__class__.__name__}
+        )
+        raise HTTPException(status_code=502, detail="evolution unreachable") from exc

--- a/backend/app/api/security.py
+++ b/backend/app/api/security.py
@@ -1,0 +1,25 @@
+"""Dependências de segurança comuns."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import Header, HTTPException
+
+from app.core.config import get_settings
+
+
+async def require_admin_token(
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
+) -> None:
+    """Valida o header `X-Admin-Token` contra `settings.admin_api_token`.
+
+    - Sem token configurado no servidor → 503 (rejeita por segurança).
+    - Sem header ou header inválido → 401.
+    - Comparação via `hmac.compare_digest` para timing-safe.
+    """
+    settings = get_settings()
+    if not settings.admin_api_token:
+        raise HTTPException(status_code=503, detail="admin endpoints not configured")
+    if not x_admin_token or not hmac.compare_digest(x_admin_token, settings.admin_api_token):
+        raise HTTPException(status_code=401, detail="invalid admin token")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -56,6 +56,11 @@ class Settings(BaseSettings):
     # ===== CORS / Socket.IO =====
     socket_cors_origins: str = "http://localhost:5173"
 
+    # ===== Admin auth (rotas /api/whatsapp/*) =====
+    # Token administrativo para proteger endpoints de gestão da instância WhatsApp.
+    # Frontend envia via header `X-Admin-Token`. Vazio = endpoints desabilitados.
+    admin_api_token: str = ""
+
     @property
     def socket_cors_origins_list(self) -> list[str]:
         return [o.strip() for o in self.socket_cors_origins.split(",") if o.strip()]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       EVOLUTION_INSTANCE: ${EVOLUTION_INSTANCE:-contactpro}
       EVOLUTION_WEBHOOK_URL: ${EVOLUTION_WEBHOOK_URL:-http://backend:8000/api/webhooks/evolution}
       SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-http://localhost:5173}
+      ADMIN_API_TOKEN: ${ADMIN_API_TOKEN}
     ports:
       - "${APP_PORT:-8000}:8000"
     healthcheck:
@@ -135,6 +136,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:8000}
+        VITE_ADMIN_TOKEN: ${VITE_ADMIN_TOKEN}
     container_name: contactpro-frontend
     depends_on:
       backend:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,10 @@ RUN npm ci
 
 FROM node:24-alpine AS builder
 WORKDIR /app
+ARG VITE_API_URL=http://localhost:8000
+ARG VITE_ADMIN_TOKEN=
+ENV VITE_API_URL=${VITE_API_URL} \
+    VITE_ADMIN_TOKEN=${VITE_ADMIN_TOKEN}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Descrição

Endurece os endpoints proxy `/api/whatsapp/*` (gestão da instância e QR Code) com autenticação obrigatória via header `X-Admin-Token`.

## Tipo

- [x] fix

## Conteúdo

### Backend
- `Settings.admin_api_token` novo (vazio → endpoints desabilitados via 503)
- `app/api/security.py:require_admin_token` valida `X-Admin-Token` com `hmac.compare_digest` (timing-safe)
- Router `/api/whatsapp/*` aplica `dependencies=[Depends(require_admin_token)]` em todas as rotas
- Bonus: 502 do proxy não vaza `str(exc)` (apenas mensagem genérica + log estruturado)

### Frontend
- `lib/api.ts` injeta `X-Admin-Token` automaticamente em paths `/api/whatsapp/*` via `VITE_ADMIN_TOKEN` (build-time)
- Dockerfile recebe `ARG VITE_API_URL` e `ARG VITE_ADMIN_TOKEN`
- Compose propaga via `args:` na build do frontend

### Config
- `.env.example` ganhou `ADMIN_API_TOKEN` e `VITE_ADMIN_TOKEN` (mesmo valor por default em dev)

## Smoke test

- `uv run python -c "from app.api.routes.whatsapp import router; print(len(router.dependencies))"` → 1 ✓
- `cd frontend && npm run build` → tsc strict + Vite verde (302 KB JS)
- `docker compose config --quiet` ✓

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)