### PR TITLE
chore(ai): derive Anthropic tool schema from AIResponse Pydantic (Closes #35)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -369,3 +369,28 @@ LeadPanel + status pills + intent badges já estavam no PR #10. Marcado completo
 - Bonus: response do orchestrator não vaza `str(exc)`; helper `_mask_jid` para PII em logs.
 
 **Tempo:** ~15 min.
+
+---
+
+## 2026-04-25 15:00 — PR de follow-up C: derivar Anthropic tool schema do Pydantic (#35)
+
+**Decisões:**
+- `_build_emit_tool_schema()` deriva `input_schema` de `AIResponse.model_json_schema()`. Helper `_resolve_refs` inline `$ref → $defs/X` recursivamente (Anthropic não resolve `$defs` automaticamente).
+- Schema antigo (~70 linhas hard-coded) removido. `EMIT_TOOL_SCHEMA` agora calculado uma vez no import.
+- Smoke: round-trip — payload de exemplo com 9 intents válidos passa em `AIResponse.model_validate`.
+- Bonus: removido `_to_dict` que era dead code (achado [Baixo] do code review do PR #24).
+- `services/ai/CLAUDE.md` atualizado: regra agora é "schema gerado de `AIResponse`; mude o Pydantic, não o tool".
+
+**Tempo:** ~10 min.
+
+---
+
+## Recap — todos os 5 follow-ups fechados
+
+| Issue | PR follow-up | Status |
+|---|---|---|
+| #31 webhook apikey | #36 | ✅ merged |
+| #32 race idempotência | #36 | ✅ merged |
+| #34 body cap | #36 | ✅ merged |
+| #33 admin auth proxy | #37 | ✅ merged |
+| #35 schema derivation | (pending PR C) | ⏳ open |

--- a/backend/app/services/ai/CLAUDE.md
+++ b/backend/app/services/ai/CLAUDE.md
@@ -6,7 +6,7 @@
 
 1. **Output sempre estruturado.** O orchestrator depende de `AIResponse{reply, intent, lead_extracted, status_suggestion}`. Cada provider faz o que for preciso para garantir esse shape.
 2. **OpenAI**: `client.chat.completions.parse(response_format=AIResponse)`. Não usar `response_format={type: json_schema, ...}` cru (mais frágil em 2026).
-3. **Anthropic**: `tool_choice={"type":"tool","name":"emit_response"}` forçado, com `input_schema` explícito (espelha o `AIResponse`). System prompt em **block list** com `cache_control: ephemeral` para reduzir custo do KB Contact Pro em ~90% após a 1ª chamada.
+3. **Anthropic**: `tool_choice={"type":"tool","name":"emit_response"}` forçado. **`input_schema` é derivado automaticamente de `AIResponse.model_json_schema()`** (em `_build_emit_tool_schema`) — sem hard-code, sem drift. System prompt em **block list** com `cache_control: ephemeral` para reduzir custo do KB Contact Pro em ~90% após a 1ª chamada.
 4. **Não usar `extended_thinking`** no Anthropic provider — incompatível com tool_choice forçado.
 5. **Vision** vive no mesmo provider (mesma API key); orchestrator descreve a imagem em texto e alimenta o pipeline de conversa.
 
@@ -34,7 +34,7 @@ ANTHROPIC_API_KEY=...         # explícito
 
 - Importar `OpenAIProvider`/`AnthropicProvider` direto em outros módulos — use `get_ai_provider()`.
 - Inserir `temperature=0` no provider Anthropic — devolve respostas robóticas. Default `0.4`.
-- Modificar `EMIT_TOOL_SCHEMA` sem refletir em `AIResponse` (test break imediato).
+- Editar `EMIT_TOOL_SCHEMA` à mão — o schema é gerado de `AIResponse`. Para mudar o contrato, mude o Pydantic.
 - Usar `print` para logar respostas — `logger.info({...})` estruturado.
 - Hard-code de prompt em outro lugar — único lugar é `prompts.py:build_system_prompt`.
 

--- a/backend/app/services/ai/anthropic_provider.py
+++ b/backend/app/services/ai/anthropic_provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -13,62 +12,56 @@ from app.services.ai.base import AIResponse, ChatTurn
 
 logger = logging.getLogger(__name__)
 
-# Schema do tool — mesmo shape do AIResponse Pydantic.
-EMIT_TOOL_SCHEMA: dict[str, Any] = {
-    "name": "emit_response",
-    "description": (
-        "Emite a resposta estruturada do assistente comercial."
-        " Sempre que receber input do usuário, chame esta tool com a estrutura completa."
-    ),
-    "input_schema": {
-        "type": "object",
-        "additionalProperties": False,
-        "required": ["reply", "intent", "lead_extracted"],
-        "properties": {
-            "reply": {"type": "string"},
-            "intent": {
-                "type": "string",
-                "enum": [
-                    "contact_z",
-                    "contact_tel",
-                    "mailing",
-                    "data_enrichment",
-                    "pricing",
-                    "human_handoff",
-                    "opt_out",
-                    "support",
-                    "general_question",
-                ],
-            },
-            "lead_extracted": {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    "name": {"type": ["string", "null"]},
-                    "company": {"type": ["string", "null"]},
-                    "phone": {"type": ["string", "null"]},
-                    "service_interest": {
-                        "type": ["string", "null"],
-                        "enum": [
-                            "contact_z",
-                            "contact_tel",
-                            "mailing",
-                            "data_enrichment",
-                            "unknown",
-                            None,
-                        ],
-                    },
-                    "lead_goal": {"type": ["string", "null"]},
-                    "estimated_volume": {"type": ["string", "null"]},
-                },
-            },
-            "status_suggestion": {
-                "type": ["string", "null"],
-                "enum": ["new", "qualified", "needs_human", "opt_out", None],
-            },
-        },
-    },
-}
+
+def _resolve_refs(schema: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
+    """Inline `$ref` referenciando `$defs` para o formato esperado pela Anthropic.
+
+    A Anthropic Tools API aceita JSON Schema mas não resolve `$defs` automaticamente.
+    Esta função substitui `{"$ref": "#/$defs/X"}` pelo schema concreto, recursivamente.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        if ref.startswith("#/$defs/"):
+            name = ref.split("/", 2)[-1]
+            target = defs.get(name, {})
+            return _resolve_refs(target, defs)
+        return schema
+    out: dict[str, Any] = {}
+    for k, v in schema.items():
+        if k == "$defs":
+            continue
+        if isinstance(v, dict):
+            out[k] = _resolve_refs(v, defs)
+        elif isinstance(v, list):
+            out[k] = [_resolve_refs(item, defs) if isinstance(item, dict) else item for item in v]
+        else:
+            out[k] = v
+    return out
+
+
+def _build_emit_tool_schema() -> dict[str, Any]:
+    """Deriva o `input_schema` do tool emit_response a partir de `AIResponse`.
+
+    Issue #35: evita drift entre o JSON Schema do tool e o Pydantic. Qualquer
+    campo novo no `AIResponse` reflete automaticamente no contrato Anthropic.
+    """
+    schema = AIResponse.model_json_schema()
+    defs = schema.get("$defs", {})
+    inlined = _resolve_refs(schema, defs)
+    inlined["additionalProperties"] = False
+    return {
+        "name": "emit_response",
+        "description": (
+            "Emite a resposta estruturada do assistente comercial."
+            " Sempre que receber input do usuário, chame esta tool com a estrutura completa."
+        ),
+        "input_schema": inlined,
+    }
+
+
+EMIT_TOOL_SCHEMA: dict[str, Any] = _build_emit_tool_schema()
 
 
 class AnthropicProvider:
@@ -160,12 +153,3 @@ class AnthropicProvider:
             if text:
                 parts.append(text)
         return "\n".join(parts).strip()
-
-
-# Helper para ler dict tipados (caso anthropic SDK retorne via .dict())
-def _to_dict(obj: Any) -> dict[str, Any]:
-    if isinstance(obj, dict):
-        return obj
-    if hasattr(obj, "model_dump"):
-        return obj.model_dump()
-    return json.loads(json.dumps(obj, default=str))


### PR DESCRIPTION
## Descrição

Elimina o drift entre `EMIT_TOOL_SCHEMA` (Anthropic) e `AIResponse` (Pydantic). O schema agora é derivado automaticamente — qualquer campo novo no `AIResponse` reflete no contrato Anthropic sem edição manual.

## Tipo

- [x] chore (refactor)

## Conteúdo

- `_build_emit_tool_schema()` chama `AIResponse.model_json_schema()` e inline os `$ref` em `$defs` (Anthropic Tools API não resolve `$defs` automaticamente)
- `_resolve_refs()` recursivo substitui `{"$ref": "#/$defs/X"}` pelo schema concreto
- `EMIT_TOOL_SCHEMA` agora calculado uma única vez no import; ~70 linhas de schema hard-coded **removidas**
- `services/ai/CLAUDE.md` atualizado: regra agora é "schema gerado de `AIResponse`; mude o Pydantic, não o tool"

### Bônus (achados [Baixo] do code review do PR #24)

- `_to_dict` era dead code — removido
- `import json` agora desnecessário — removido

## Smoke test

Round-trip:

\`\`\`python
sample = {
    'reply': 'Olá!',
    'intent': 'general_question',
    'lead_extracted': {'name': 'Vinícius', 'company': None, ...},
    'status_suggestion': 'new',
}
AIResponse.model_validate(sample)  # ✓ passes
\`\`\`

Schema top-level: `['intent', 'lead_extracted', 'reply', 'status_suggestion']`. Intent enum: 9 valores.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)