### PR TITLE
revert: WHATSAPP_ALLOWED_NUMBERS whitelist (não faz sentido no escopo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,9 +51,3 @@ SOCKET_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Frontend recebe via VITE_ADMIN_TOKEN (build-time) e envia em X-Admin-Token.
 ADMIN_API_TOKEN=change-me-admin-token
 VITE_ADMIN_TOKEN=change-me-admin-token
-
-# ===== Whitelist de números (modo dev) =====
-# Lista separada por vírgula. Apenas dígitos (com código do país, sem +/() ou @s.whatsapp.net).
-# Vazio = sem filtro (responde todo mundo). Útil para testar sem responder leads aleatórios.
-# Ex: WHATSAPP_ALLOWED_NUMBERS=5511999999999,5521988887777
-WHATSAPP_ALLOWED_NUMBERS=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -61,18 +61,6 @@ class Settings(BaseSettings):
     # Frontend envia via header `X-Admin-Token`. Vazio = endpoints desabilitados.
     admin_api_token: str = ""
 
-    # ===== Whitelist de números (modo desenvolvimento) =====
-    # Lista separada por vírgula de números (com ou sem código do país, sem `@s.whatsapp.net`).
-    # Ex: "5511999999999,5521988887777". Vazio = sem filtro (responde todo mundo).
-    # Útil em dev para o bot só responder ao seu próprio número durante testes.
-    whatsapp_allowed_numbers: str = ""
-
-    @property
-    def whatsapp_allowed_numbers_list(self) -> list[str]:
-        """Números normalizados (apenas dígitos)."""
-        raw = [n.strip() for n in self.whatsapp_allowed_numbers.split(",") if n.strip()]
-        return ["".join(c for c in n if c.isdigit()) for n in raw if any(c.isdigit() for c in n)]
-
     @property
     def socket_cors_origins_list(self) -> list[str]:
         return [o.strip() for o in self.socket_cors_origins.split(",") if o.strip()]

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -15,7 +15,6 @@ Cérebro do sistema. Recebe `ParsedMessage` do webhook Evolution e administra to
 5. **Reaction 👍 é fire-and-forget.** Falha não interrompe o pipeline (apenas loga warning).
 6. **Smart reaction final** depende do `status` do lead pós-AI: ✅ qualified, 👌 opt_out, 🤝 needs_human, 👍 new.
 7. **Histórico tem cap de 12 mensagens** (`HISTORY_LIMIT`) para controlar custo de prompt e latência.
-8. **Whitelist de números** (`WHATSAPP_ALLOWED_NUMBERS` env) — quando preenchida, mensagens de números fora da lista são ignoradas em silêncio (não persiste, não reage, não chama IA). Vazia = sem filtro.
 
 ### Pipeline (texto)
 

--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -175,19 +175,6 @@ class ConversationOrchestrator:
             # mensagens enviadas pelo próprio bot — ignoramos no pipeline (ack via emit ja sai pelo fluxo OUT)
             return
 
-        # 0. whitelist de números (modo dev). Vazio = aceita todo mundo.
-        from app.core.config import get_settings
-
-        allowed = get_settings().whatsapp_allowed_numbers_list
-        if allowed:
-            phone = jid_to_phone(parsed.remote_jid)
-            if phone not in allowed:
-                logger.info(
-                    "orchestrator_number_not_allowed",
-                    extra={"phone_suffix": phone[-4:] if phone else "?"},
-                )
-                return
-
         # 1. idempotência
         if await self._exists_message(parsed.whatsapp_message_id):
             logger.info("orchestrator_duplicate_ignored", extra={"id": parsed.whatsapp_message_id})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
     ports:
-      - "5433:5432"   # 5432 da host pode estar em uso por outro stack; rede interna do compose ainda usa 5432
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-contactpro} -d ${POSTGRES_DB:-contactpro}"]
       interval: 5s
@@ -31,7 +31,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6380:6379"   # idem 6380 host -> 6379 container
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -123,7 +123,6 @@ services:
       EVOLUTION_WEBHOOK_URL: ${EVOLUTION_WEBHOOK_URL:-http://backend:8000/api/webhooks/evolution}
       SOCKET_CORS_ORIGINS: ${SOCKET_CORS_ORIGINS:-http://localhost:5173}
       ADMIN_API_TOKEN: ${ADMIN_API_TOKEN}
-      WHATSAPP_ALLOWED_NUMBERS: ${WHATSAPP_ALLOWED_NUMBERS:-}
     ports:
       - "${APP_PORT:-8000}:8000"
     healthcheck:


### PR DESCRIPTION
## Descrição

Reverte o PR #39. Decidimos não manter a whitelist de números — está fora do escopo do produto e o orchestrator deve responder a qualquer lead.

Para limitar tráfego em desenvolvimento, a alternativa é parear uma conta WhatsApp dedicada de teste em vez de filtrar no código.

## Tipo

- [x] revert / chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)