### PR TITLE
fix(webhook): Evolution envia apikey via header customizado (regressão #31)

### DIFF
--- a/backend/app/api/routes/whatsapp.py
+++ b/backend/app/api/routes/whatsapp.py
@@ -69,9 +69,12 @@ async def setup_webhook() -> dict:
     settings = get_settings()
     client = get_evolution_client()
     try:
+        # Repassa `apikey` como header customizado nos webhooks do Evolution para
+        # nosso backend conseguir validar a origem (issue #31 deixou apikey obrigatório).
         return await client.set_webhook(
             url=settings.evolution_webhook_url,
             base64=True,
+            headers={"apikey": settings.evolution_api_key},
         )
     except EvolutionAPIError as exc:
         # Não vaza str(exc) (URLs internas / hints SQL); detalhe completo vai para o log.

--- a/backend/app/services/whatsapp/evolution_client.py
+++ b/backend/app/services/whatsapp/evolution_client.py
@@ -118,6 +118,7 @@ class EvolutionClient:
         url: str,
         events: list[str] | None = None,
         base64: bool = True,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         events = events or [
             "MESSAGES_UPSERT",
@@ -125,18 +126,21 @@ class EvolutionClient:
             "QRCODE_UPDATED",
             "SEND_MESSAGE",
         ]
+        webhook_body: dict[str, Any] = {
+            "enabled": True,
+            "url": url,
+            "byEvents": False,
+            "base64": base64,
+            "events": events,
+        }
+        # Evolution v2 não envia `apikey` automaticamente nas chamadas de webhook;
+        # passamos via `headers` para o nosso backend conseguir validar a origem.
+        if headers:
+            webhook_body["headers"] = headers
         return await self._request(
             "POST",
             f"/webhook/set/{self.instance}",
-            json={
-                "webhook": {
-                    "enabled": True,
-                    "url": url,
-                    "byEvents": False,
-                    "base64": base64,
-                    "events": events,
-                }
-            },
+            json={"webhook": webhook_body},
         )
 
     # ===== Send =====


### PR DESCRIPTION
Sintoma: 401 em todos os webhooks após parear → orchestrator nunca processou nenhuma mensagem.

Causa: #31 tornou `apikey` obrigatório, mas Evolution v2 não envia o header por default.

Fix: `set_webhook(headers={'apikey': EVOLUTION_API_KEY})` — Evolution suporta `webhook.headers` no payload de configuração, sem precisar relaxar a validação no backend.

Após merge: re-clicar em **Inicializar instância** na UI (re-aplica o setup do webhook com o novo header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)