### PR TITLE
chore(compose): parametriza portas host de Postgres e Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,7 @@ SOCKET_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Frontend recebe via VITE_ADMIN_TOKEN (build-time) e envia em X-Admin-Token.
 ADMIN_API_TOKEN=change-me-admin-token
 VITE_ADMIN_TOKEN=change-me-admin-token
+
+# ===== Portas na host (override quando 5432 / 6379 já estão em uso) =====
+POSTGRES_HOST_PORT=5432
+REDIS_HOST_PORT=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-contactpro} -d ${POSTGRES_DB:-contactpro}"]
       interval: 5s
@@ -31,7 +31,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      - "${REDIS_HOST_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
Permite override via .env quando 5432/6379 já estão ocupadas. Default inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)