### PR TITLE
fix(tts,orchestrator): bytes async streaming + fallback texto robusto

### DIFF
--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -380,9 +380,36 @@ class ConversationOrchestrator:
                 except EvolutionAPIError as exc2:
                     msg_out.error_reason = (msg_out.error_reason or "") + f" | fallback falhou: {exc2}"
         except Exception as exc:  # noqa: BLE001
-            logger.exception("send_unexpected", extra={"error": str(exc)})
+            logger.exception(
+                "send_unexpected",
+                extra={"error_class": exc.__class__.__name__, "type": out_type.value},
+            )
             msg_out.status = MessageStatus.FAILED
-            msg_out.error_reason = str(exc)
+            msg_out.error_reason = f"{exc.__class__.__name__}: {exc}"
+            # Fallback texto cobre QUALQUER falha em áudio (TTS quebrou, mime errado, etc).
+            if out_type == MessageType.AUDIO:
+                try:
+                    await self.whatsapp.send_text(
+                        number=jid_to_phone(parsed.remote_jid),
+                        text=ai_resp.reply,
+                        quoted={
+                            "key": {
+                                "remoteJid": parsed.remote_jid,
+                                "fromMe": False,
+                                "id": parsed.whatsapp_message_id,
+                            },
+                            "message": {"conversation": parsed.text or ""},
+                        },
+                    )
+                    msg_out.status = MessageStatus.SENT
+                    msg_out.type = MessageType.TEXT  # converte para texto na persistência
+                    msg_out.error_reason = (
+                        (msg_out.error_reason or "") + " | fallback texto enviado"
+                    )
+                except Exception as exc2:  # noqa: BLE001
+                    msg_out.error_reason = (msg_out.error_reason or "") + (
+                        f" | fallback falhou: {exc2.__class__.__name__}"
+                    )
         finally:
             self.session.add(msg_out)
             await self.session.commit()

--- a/backend/app/services/tts/openai_tts.py
+++ b/backend/app/services/tts/openai_tts.py
@@ -34,18 +34,19 @@ class OpenAITTS:
         if instructions and self.model.startswith("gpt-4o-mini-tts"):
             kwargs["instructions"] = instructions
         try:
-            resp = await self.client.audio.speech.create(**kwargs)
+            # `with_streaming_response` é o caminho correto para obter bytes em SDKs >=1.50;
+            # `create` direto retorna `LegacyAPIResponse` cujo `.content` já é bytes (sync),
+            # mas para evitar a deprecação de `LegacyAPIResponse.read()` usamos streaming.
+            async with self.client.audio.speech.with_streaming_response.create(
+                **kwargs
+            ) as resp:
+                chunks = []
+                async for chunk in resp.iter_bytes():
+                    chunks.append(chunk)
+                return b"".join(chunks)
         except Exception as exc:  # noqa: BLE001
             logger.exception("tts_failed", extra={"model": self.model, "error": str(exc)})
             raise
-
-        # SDK retorna `HttpxBinaryResponseContent` — usar .read() / .iter_bytes()
-        if hasattr(resp, "read"):
-            return await resp.read() if hasattr(resp.read, "__call__") and hasattr(resp, "aiter_bytes") else resp.read()
-        if hasattr(resp, "content"):
-            return resp.content
-        # Fallback: serializa
-        return bytes(resp)
 
 
 _singleton: OpenAITTS | None = None


### PR DESCRIPTION
Hotfix: TTS quebrava com `TypeError: object bytes can't be used in 'await' expression` em runtime ao responder áudio. Implementação correta usa `with_streaming_response` + `iter_bytes`.

Bonus (achado [Médio] do code review do PR #25): fallback texto agora cobre **qualquer** exceção em áudio, não só `EvolutionAPIError`. Isso garante que o lead sempre recebe a resposta — em texto se TTS falhar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)