### PR TITLE
fix(frontend): badge wa: unknown — hidrata estado via REST + polling backup

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -659,3 +659,41 @@ curl -s http://localhost:5173/conversations/abc-123    # HTTP 200 (SPA fallback)
 ```
 
 **Tempo:** ~60min.
+
+---
+
+## 2026-04-25 18:30 — PR #56 / Issue #55: fix do badge wa: unknown via fetch inicial + polling backup
+
+**Contexto:** bug visível pós-Spec A: badge `wa:` no header mostra `unknown` mesmo com instância pareada (`state: open` na Evolution). Causa: o evento Socket.IO `wa.connection.update` só dispara em MUDANÇA de estado; se a página carrega depois, nunca vê o evento.
+
+**Decisões:**
+- Novo `useWhatsAppConnection` (TanStack Query) em `hooks/useWhatsAppConnection.ts` consumindo `/api/whatsapp/connection` com `refetchInterval: 60_000` (backup contra eventos perdidos).
+- `lib/api.ts` ganha `fetchWhatsAppConnection()` que **achata** o nested `{instance:{state}}` da Evolution v2 para `{state}` plano e degrada graciosamente para `{state: 'unknown'}` em 502 (`evolution unreachable`) — UX prefere "estado indeterminado" a quebrar a UI inteira. Validação contra a allow-list de estados (`open`/`connecting`/`close`/`unknown`) — qualquer valor desconhecido também cai pra `unknown`.
+- `lib/queryKeys.ts` ganha `whatsappKeys` factory.
+- `hooks/useConnectionStatus.ts` refatorado: agora **mescla** query (state) + socket-context (qrcode). Retorna `{state, qrcode, isLoading}`.
+- `providers/SocketProvider.tsx` no handler de `wa.connection.update` adiciona `queryClient.setQueryData(whatsappKeys.connection(), {state: data.state})` em paralelo ao `setWaState` existente. UI reage imediato a evento socket E ao polling backup.
+- `types/domain.ts` ganha `WhatsAppConnectionResponse`.
+- 8 testes novos (49 total agora):
+  - `useWhatsAppConnection.test.tsx`: chama URL correto, parsea `{instance:{state}}`, aceita `{state}` no topo, fallback `unknown` em 502, fallback em valor desconhecido.
+  - `useConnectionStatus.test.tsx`: loading inicial, state do cache, reage a updates do cache, qrcode vem do socket-context.
+  - `SocketProvider.test.tsx`: novo caso testando que `wa.connection.update` escreve no `whatsappKeys.connection()` cache.
+
+**Trade-offs:**
+- Mantive `setWaState` no SocketProvider em paralelo ao `setQueryData` — `useSocketContext().waState` ainda é exposto pra eventual consumidor que use Context direto. Refator final pra mover 100% pro query fica para uma PR específica (footprint menor agora).
+- Polling de 60s é conservador — 30s daria reação mais rápida a desync, 120s seria mais leve. Escolhi 60s como meio-termo razoável; trivial ajustar.
+
+**Smoke test:**
+```bash
+cd frontend
+npm run typecheck    # OK
+npm run lint         # 0 erros
+npm run test         # 49/49 passing in ~4s
+npm run test:coverage # 85.4% / 67% / 87.5% / 91.2% (acima dos thresholds 80/60/80/80)
+npm run build        # initial 400KB / gzip 126KB
+
+docker compose up -d --build frontend
+# Browser http://localhost:5173/
+# Recarregar (com instância pareada): badge "wa: open" aparece em < 1s.
+```
+
+**Tempo:** ~45min.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -39,7 +39,8 @@ src/
     lead/                       # LeadPanel
     connection/                 # QRCodePanel, ConnectionStatus
   hooks/
-    useConnectionStatus.ts      # re-export do SocketProvider context
+    useConnectionStatus.ts      # merge query+context — {state, qrcode, isLoading}
+    useWhatsAppConnection.ts    # useQuery(/api/whatsapp/connection) com polling 60s
     useConversationsQuery.ts    # useQuery(['conversations', 'list', filters])
     useConversationMessages.ts  # useQuery(['conversations', 'detail', id, 'messages'])
     useLead.ts                  # useQuery(['leads', 'detail', id])

--- a/frontend/src/hooks/CLAUDE.md
+++ b/frontend/src/hooks/CLAUDE.md
@@ -18,7 +18,8 @@
 | `useConversationsQuery(filters?)` | Lista de conversas via REST. SocketProvider invalida quando chega mensagem (reordenar por last_message_at). |
 | `useConversationMessages(id?)` | Página de mensagens de uma conversa via REST. SocketProvider mescla mensagens novas via `setQueryData`. |
 | `useLead(id?)` | Detalhe completo do Lead via REST. SocketProvider atualiza via `lead.updated`. |
-| `useConnectionStatus()` | Re-export fino do `useSocketContext()` — `{ state, qrcode }` para WhatsApp connection state. |
+| `useWhatsAppConnection()` | Estado da conexão WhatsApp via REST (`/api/whatsapp/connection`) com polling backup de 60s. SocketProvider faz `setQueryData` quando chega `wa.connection.update` para resposta imediata. |
+| `useConnectionStatus()` | Merge: `state` vem do `useWhatsAppConnection()` query (REST + socket), `qrcode` vem do `useSocketContext()` (evento puro). Retorna `{state, qrcode, isLoading}`. |
 
 ## Não fazer
 

--- a/frontend/src/hooks/useConnectionStatus.test.tsx
+++ b/frontend/src/hooks/useConnectionStatus.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Verifica o merge de state (TanStack Query) + qrcode (SocketContext) que o
+ * `useConnectionStatus` faz para o header e demais consumidores da UI.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { whatsappKeys } from '@/lib/queryKeys'
+import { SocketContext, type SocketContextValue } from '@/providers/socket-context'
+import { makeTestQueryClient } from '@/test/test-utils'
+
+import { useConnectionStatus } from './useConnectionStatus'
+
+function withProviders(client: QueryClient, socketValue: SocketContextValue) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <SocketContext.Provider value={socketValue}>{children}</SocketContext.Provider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+const baseSocket: SocketContextValue = {
+  connected: false,
+  waState: 'unknown',
+  qrcode: null,
+  thinking: {},
+}
+
+describe('useConnectionStatus', () => {
+  beforeEach(() => {
+    // Mock vazio — o hook é loading-only enquanto não respondemos.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('retorna {state: unknown, isLoading: true} antes do fetch resolver', () => {
+    const client = makeTestQueryClient()
+    const { result } = renderHook(() => useConnectionStatus(), {
+      wrapper: withProviders(client, baseSocket),
+    })
+    expect(result.current.state).toBe('unknown')
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.qrcode).toBeNull()
+  })
+
+  it('usa o state cacheado quando o query resolver', () => {
+    const client = makeTestQueryClient()
+    client.setQueryData(whatsappKeys.connection(), { state: 'open' })
+
+    const { result } = renderHook(() => useConnectionStatus(), {
+      wrapper: withProviders(client, baseSocket),
+    })
+    expect(result.current.state).toBe('open')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('reage a updates do cache em tempo real (simula evento Socket.IO)', async () => {
+    const client = makeTestQueryClient()
+    client.setQueryData(whatsappKeys.connection(), { state: 'connecting' })
+
+    const { result } = renderHook(() => useConnectionStatus(), {
+      wrapper: withProviders(client, baseSocket),
+    })
+    expect(result.current.state).toBe('connecting')
+
+    // SocketProvider faz isto quando chega `wa.connection.update`.
+    client.setQueryData(whatsappKeys.connection(), { state: 'open' })
+
+    await waitFor(() => expect(result.current.state).toBe('open'))
+  })
+
+  it('qrcode vem do SocketContext, não do query', () => {
+    const client = makeTestQueryClient()
+    client.setQueryData(whatsappKeys.connection(), { state: 'connecting' })
+    const socket = { ...baseSocket, qrcode: 'data:image/png;base64,iVBOR' }
+
+    const { result } = renderHook(() => useConnectionStatus(), {
+      wrapper: withProviders(client, socket),
+    })
+    expect(result.current.qrcode).toBe('data:image/png;base64,iVBOR')
+  })
+})

--- a/frontend/src/hooks/useConnectionStatus.ts
+++ b/frontend/src/hooks/useConnectionStatus.ts
@@ -1,20 +1,31 @@
 /**
- * Re-export das infos de conexão a partir do SocketProvider.
+ * Estado da conexão WhatsApp + QR Code para a UI.
  *
- * Antes da Phase 2, este hook fazia `socket.on(...)` direto. Agora o
- * SocketProvider centraliza handlers e expõe via Context — evita N
- * subscribers para o mesmo evento.
+ * `state` vem do TanStack Query (REST + atualizações Socket.IO mescladas no
+ * cache pelo `SocketProvider`). Enquanto a primeira request está em voo,
+ * devolve `unknown` + `isLoading: true` — UX prefere placeholder a flicker.
+ *
+ * `qrcode` continua vindo do `useSocketContext()` (é evento puro, sem
+ * cache REST).
  */
 
 import { useSocketContext } from '@/providers/socket-context'
 import type { ConnectionState } from '@/types/domain'
 
+import { useWhatsAppConnection } from './useWhatsAppConnection'
+
 interface ConnectionInfo {
   state: ConnectionState
   qrcode: string | null
+  isLoading: boolean
 }
 
 export function useConnectionStatus(): ConnectionInfo {
-  const { waState, qrcode } = useSocketContext()
-  return { state: waState, qrcode }
+  const { qrcode } = useSocketContext()
+  const { data, isLoading } = useWhatsAppConnection()
+  return {
+    state: data?.state ?? 'unknown',
+    qrcode,
+    isLoading,
+  }
 }

--- a/frontend/src/hooks/useWhatsAppConnection.test.tsx
+++ b/frontend/src/hooks/useWhatsAppConnection.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Garante que o hook chama o endpoint REST correto, normaliza o response
+ * nested do Evolution e degrada graciosamente em 502.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AllProviders, makeTestQueryClient } from '@/test/test-utils'
+
+import { useWhatsAppConnection } from './useWhatsAppConnection'
+
+function mockFetchOnce(response: Response | (() => Response)) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => (typeof response === 'function' ? response() : response))
+  )
+}
+
+describe('useWhatsAppConnection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('chama /api/whatsapp/connection e devolve {state} achatado', async () => {
+    mockFetchOnce(
+      new Response(JSON.stringify({ instance: { instanceName: 'contactpro', state: 'open' } }), {
+        status: 200,
+      })
+    )
+    const client = makeTestQueryClient()
+
+    const { result } = renderHook(() => useWhatsAppConnection(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual({ state: 'open' })
+    const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    expect(calledUrl).toMatch(/\/api\/whatsapp\/connection$/)
+  })
+
+  it('aceita state no topo do payload (caso o backend mude futuramente)', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ state: 'connecting' }), { status: 200 }))
+    const client = makeTestQueryClient()
+
+    const { result } = renderHook(() => useWhatsAppConnection(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({ state: 'connecting' })
+  })
+
+  it('502 do proxy degrada para {state: unknown} sem propagar erro', async () => {
+    mockFetchOnce(
+      new Response(JSON.stringify({ detail: 'evolution unreachable' }), { status: 502 })
+    )
+    const client = makeTestQueryClient()
+
+    const { result } = renderHook(() => useWhatsAppConnection(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+
+    expect(result.current.data).toEqual({ state: 'unknown' })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('valor desconhecido vindo do backend cai em {state: unknown}', async () => {
+    mockFetchOnce(
+      new Response(JSON.stringify({ instance: { state: 'banana' } }), { status: 200 })
+    )
+    const client = makeTestQueryClient()
+
+    const { result } = renderHook(() => useWhatsAppConnection(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({ state: 'unknown' })
+  })
+})

--- a/frontend/src/hooks/useWhatsAppConnection.ts
+++ b/frontend/src/hooks/useWhatsAppConnection.ts
@@ -1,0 +1,24 @@
+/**
+ * Estado atual da conexão WhatsApp via REST.
+ *
+ * Por que existe: o evento Socket.IO `wa.connection.update` só dispara em
+ * MUDANÇA de estado. Quando a página carrega depois da instância já estar
+ * pareada, sem fetch inicial o frontend ficaria travado em `unknown`. O
+ * polling de 60s é backup contra eventos perdidos (socket reconnect, server
+ * restart, etc.) — atualizações em tempo real continuam vindo do socket via
+ * `setQueryData` no `SocketProvider`.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchWhatsAppConnection } from '@/lib/api'
+import { whatsappKeys } from '@/lib/queryKeys'
+
+export function useWhatsAppConnection() {
+  return useQuery({
+    queryKey: whatsappKeys.connection(),
+    queryFn: fetchWhatsAppConnection,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,10 +2,12 @@
 // (ver hooks/use*.ts).
 
 import type {
+  ConnectionState,
   ConversationDetail,
   ConversationListResponse,
   Lead,
   MessagePageResponse,
+  WhatsAppConnectionResponse,
 } from '@/types/domain'
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
@@ -85,4 +87,31 @@ export async function fetchMessages(
 
 export async function fetchLead(id: string): Promise<Lead> {
   return api<Lead>(`/api/leads/${id}`)
+}
+
+/** Estado da conexão WhatsApp via backend proxy → Evolution.
+ *
+ * Evolution v2 devolve `{ instance: { instanceName, state } }`. Achatamos para
+ * `{ state }` e tratamos 502 (proxy retorna `evolution unreachable`) como
+ * `unknown` em vez de propagar o erro — UX prefere "estado indeterminado"
+ * a quebrar a UI inteira.
+ */
+export async function fetchWhatsAppConnection(): Promise<WhatsAppConnectionResponse> {
+  const KNOWN_STATES: readonly ConnectionState[] = ['open', 'connecting', 'close', 'unknown']
+  try {
+    const raw = await api<{ instance?: { state?: string } } & { state?: string }>(
+      '/api/whatsapp/connection'
+    )
+    const candidate = raw?.instance?.state ?? raw?.state
+    const state = KNOWN_STATES.includes(candidate as ConnectionState)
+      ? (candidate as ConnectionState)
+      : 'unknown'
+    return { state }
+  } catch (err) {
+    // Evolution fora do ar (proxy 502) ou rede caiu — não quebra a UI.
+    if (err instanceof Error && err.message.startsWith('502')) {
+      return { state: 'unknown' }
+    }
+    throw err
+  }
 }

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -23,3 +23,8 @@ export const leadKeys = {
   all: ['leads'] as const,
   detail: (id: string) => [...leadKeys.all, 'detail', id] as const,
 }
+
+export const whatsappKeys = {
+  all: ['whatsapp'] as const,
+  connection: () => [...whatsappKeys.all, 'connection'] as const,
+}

--- a/frontend/src/providers/SocketProvider.test.tsx
+++ b/frontend/src/providers/SocketProvider.test.tsx
@@ -12,7 +12,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { act, render, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { conversationKeys, leadKeys } from '@/lib/queryKeys'
+import { conversationKeys, leadKeys, whatsappKeys } from '@/lib/queryKeys'
 import { useSocketContext } from '@/providers/socket-context'
 import { makeTestQueryClient } from '@/test/test-utils'
 import type {
@@ -247,5 +247,21 @@ describe('SocketProvider', () => {
     expect(result.current.waState).toBe('open')
     // qrcode deve ser limpo quando state é 'open'
     expect(result.current.qrcode).toBeNull()
+  })
+
+  it('wa.connection.update escreve {state} no cache de whatsappKeys.connection', () => {
+    const { client, wrapper } = withProviders()
+    render(<div />, { wrapper })
+
+    act(() => {
+      fakeSocket.emit('wa.connection.update', { state: 'open' })
+    })
+
+    expect(client.getQueryData(whatsappKeys.connection())).toEqual({ state: 'open' })
+
+    act(() => {
+      fakeSocket.emit('wa.connection.update', { state: 'close' })
+    })
+    expect(client.getQueryData(whatsappKeys.connection())).toEqual({ state: 'close' })
   })
 })

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -16,7 +16,7 @@
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 
-import { conversationKeys, leadKeys } from '@/lib/queryKeys'
+import { conversationKeys, leadKeys, whatsappKeys } from '@/lib/queryKeys'
 import { socket } from '@/lib/socket'
 import type {
   ConnectionState,
@@ -107,7 +107,13 @@ export function SocketProvider({ children }: SocketProviderProps) {
     const onConnect = () => setConnected(true)
     const onDisconnect = () => setConnected(false)
     const onWaConnection = (data: { state: ConnectionState }) => {
+      // Atualiza tanto o state local (consumido por widgets via context) quanto
+      // o cache do TanStack Query (fonte da verdade que `useConnectionStatus`
+      // lê via `useWhatsAppConnection`). Isso garante que viewers existentes
+      // continuam funcionando E que o badge do header reage imediato sem
+      // esperar refetch.
       setWaState(data.state)
+      queryClient.setQueryData(whatsappKeys.connection(), { state: data.state })
       if (data.state === 'open') setQrcode(null)
     }
     const onQr = (data: { qrcode: string | null }) => setQrcode(data.qrcode)

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -107,3 +107,11 @@ export interface MessagePageResponse {
   next_before_id: string | null
   limit: number
 }
+
+/** Resposta normalizada do backend `/api/whatsapp/connection`.
+ * Internamente Evolution v2 devolve `{ instance: { state } }`; o fetcher
+ * achata para esta forma plana antes de cachear.
+ */
+export interface WhatsAppConnectionResponse {
+  state: ConnectionState
+}


### PR DESCRIPTION
# Descrição

Bug visível pós-Spec A: badge \`wa:\` no header mostra \`unknown\` mesmo com instância pareada (\`state: open\` na Evolution).

**Causa**: o evento Socket.IO \`wa.connection.update\` só dispara em **mudança** de estado. Se a página carrega depois da instância já estar pareada, nenhum evento chega → estado fica preso em \`unknown\`.

**Fix**: hidratar o estado inicial via REST (\`/api/whatsapp/connection\`, que já existia) e usar o polling do TanStack Query como backup contra eventos perdidos.

Closes #55.

## Tipo

- [ ] feat
- [x] fix (bug visível)
- [ ] chore
- [x] docs (CLAUDE.md atualizado)
- [ ] refactor
- [x] test (8 testes novos, 49 total)
- [ ] perf

## O que muda

- **\`hooks/useWhatsAppConnection.ts\`** (novo): \`useQuery\` contra \`/api/whatsapp/connection\` com \`refetchInterval: 60_000\` (backup contra eventos perdidos / socket reconnect / server restart).
- **\`lib/api.ts\`** ganha \`fetchWhatsAppConnection()\` que:
  - achata \`{instance:{state}}\` (Evolution v2) → \`{state}\`;
  - aceita \`{state}\` no topo (futuro-proof);
  - degrada gracioso para \`{state: 'unknown'}\` em **502 evolution unreachable** (proxy do backend);
  - valida contra a allow-list \`open|connecting|close|unknown\` — qualquer outro valor cai em \`unknown\`.
- **\`lib/queryKeys.ts\`** ganha \`whatsappKeys\` factory (\`.all\`, \`.connection()\`).
- **\`hooks/useConnectionStatus.ts\`** refatorado: agora **mescla** query (\`state\`) + socket-context (\`qrcode\`). Retorna \`{state, qrcode, isLoading}\`.
- **\`providers/SocketProvider.tsx\`** no handler de \`wa.connection.update\` adiciona \`queryClient.setQueryData(whatsappKeys.connection(), {state: data.state})\` em paralelo ao \`setWaState\` que já existia. UI reage **imediato** a evento socket E ao polling backup.
- **\`types/domain.ts\`** ganha \`WhatsAppConnectionResponse\`.

## Testes (8 novos, 49 total)

- \`useWhatsAppConnection.test.tsx\` (4 cenários):
  - chama URL correto e parsea \`{instance:{state:'open'}}\` → \`{state:'open'}\`;
  - aceita \`{state}\` no topo do payload (compat futura);
  - 502 do proxy degrada para \`{state:'unknown'}\` sem propagar erro;
  - valor desconhecido (\`'banana'\`) cai em \`unknown\`.
- \`useConnectionStatus.test.tsx\` (4 cenários):
  - sem cache: \`{state:'unknown', isLoading:true}\`;
  - com cache via \`setQueryData\`: usa o state cacheado;
  - reage a updates do cache em tempo real (simula evento socket);
  - \`qrcode\` vem do SocketContext, não do query.
- \`SocketProvider.test.tsx\` (1 caso novo):
  - \`wa.connection.update\` event escreve \`{state:'open'}\` em \`whatsappKeys.connection()\` cache.

## Checklist obrigatório

- [x] Conventional Commits (\`fix(frontend): ...\`)
- [x] CLAUDE.md atualizado (\`frontend/CLAUDE.md\` + \`frontend/src/hooks/CLAUDE.md\`)
- [x] DEVELOPMENT_LOG.md atualizado com entrada cronológica
- [x] \`vercel:react-best-practices\` aplicado (hook isolado, query keys factory, defer/await consciente, refetchIntervalInBackground=false)
- [x] \`/security-review\` — N/A: nenhuma nova entrada externa, sem novos secrets
- [x] Sem \`.env\`, chaves, sessões ou credenciais no diff
- [x] Smoke test manual realizado

## Smoke test

\`\`\`bash
cd frontend
npm run typecheck     # OK
npm run lint          # 0 erros
npm run test          # 49/49 in ~4s
npm run test:coverage # 85.4% / 67% / 87.5% / 91.2% (≥ 80/60/80/80)
npm run build         # initial 400KB / gzip 126KB

docker compose up -d --build frontend
\`\`\`

Manual:
1. Parear WhatsApp via QR → badge mostra \`wa: open\`.
2. F5 (com instância ainda pareada) → badge volta para \`open\` em < 1s (era preso em \`unknown\` antes).
3. Aguardar 65s sem evento → polling refetch mantém estado.

## Trade-offs

- **\`setWaState\` mantido** em paralelo ao \`setQueryData\` — \`useSocketContext().waState\` ainda exposto pra eventual consumer que use Context direto. Refator final pra mover 100% pro query fica para uma PR específica (footprint menor agora).
- **Polling de 60s** é meio-termo (30s = mais reativo a desync; 120s = mais leve). Trivial ajustar.