### PR TITLE
docs(readme): walkthrough completo para recrutador

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -697,3 +697,34 @@ docker compose up -d --build frontend
 ```
 
 **Tempo:** ~45min.
+
+---
+
+## 2026-04-25 18:50 — PR #58 / Issue #57: README walkthrough completo para recrutador
+
+**Contexto:** depois do Spec A + fix do connection state, faltava polish nos READMEs para recrutador clonar e rodar tudo do zero. `README.md` raiz era pré-Spec A; `frontend/README.md` ainda era boilerplate Vite; `backend/README.md` não existia.
+
+**Decisões:**
+- **`README.md` raiz** (366 linhas, +72 vs antes):
+  - Visão geral atualizada com rotas deep-linkáveis, persistência REST+Socket.IO, suíte de testes 73, cobertura 80%+.
+  - Stack ganha React Router 7, TanStack Query 5, Vitest 4 + axe-core.
+  - Nova seção "Pré-requisitos" explícita (Docker Desktop ≥24 obrigatório; Node ≥20 + uv ≥0.5 opcional).
+  - "Como rodar em 5 minutos" reformulado, com `ADMIN_API_TOKEN` agora explícito.
+  - Nova subseção "Deep-link e persistência" explicando o fluxo REST+Socket.IO.
+  - **Nova seção dedicada "Como rodar os testes"** com cmds completos para backend (`uv run pytest tests/ -v`) e frontend (`npm run test`/`test:coverage`).
+  - **Nova seção "Troubleshooting"** com 7 sintomas mapeados (badge `wa:unknown`, QR não aparece, mensagem não chega, 401 unauthorized, 502 evolution, conflito de porta, pytest falha).
+  - "Limitações" atualizada: removido "sem testes automatizados" (agora tem 73), removido "sem persistência" (agora tem REST + URL).
+  - "O que faria com mais tempo" menciona Spec B (testes backend completos) e Spec C (CI/CD + Playwright).
+  - "Status do desafio" ganha 7 checkboxes novos: responsivo, persistência, suíte de testes, a11y axe, code splitting, ErrorBoundary, workflow issue/PR/squash merge.
+- **`frontend/README.md`** (73 linhas, substitui o boilerplate Vite): stack, scripts, "Como rodar localmente sem Docker", arquitetura, convenção de testes co-located + axe + thresholds.
+- **`backend/README.md`** (86 linhas, novo): stack, "Como rodar localmente sem Docker", "Como rodar testes" (com requisito Docker para testcontainers), tabela "Como adicionar..." (endpoint/schema/service/model/teste) com links pros CLAUDE.md específicos.
+
+**Trade-offs:**
+- READMEs por módulo (`frontend/`, `backend/`) ficaram intencionalmente curtos (≤90 linhas) — apontam pro README raiz pra setup global e pros `CLAUDE.md` pra convenções detalhadas. Evita duplicação de instrução que envelhece sem aviso.
+- "Resetar a sessão WhatsApp" continua manual via `docker volume rm` (UI de logout fica fora do escopo).
+
+**Smoke (mental walkthrough do recrutador):**
+1. Clone → 2. `cp .env.example .env` + 1 chave OpenAI **ou** Anthropic + ADMIN_API_TOKEN → 3. `docker compose up --build` → < 30s tudo healthy → 4. http://localhost:5173 → 5. "Inicializar instância" → 6. QR escaneado → 7. Mensagem WhatsApp → aparece em tempo real, intent classificado, lead extraído.
+Para testes: `cd backend && uv sync && uv run pytest tests -v` (~5s) + `cd frontend && npm install && npm run test` (~4s).
+
+**Tempo:** ~30min.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Desafio Contact Pro — Chatbot WhatsApp + IA
 
-Chatbot WhatsApp com IA para atendimento inicial de leads da **Contact Pro**, com frontend web em tempo real, suporte a **texto, áudio e imagem**, qualificação automática e classificação de intenção.
+Chatbot WhatsApp com IA para atendimento inicial de leads da **Contact Pro**, com inbox web em tempo real **responsiva** (mobile/tablet/desktop), suporte a **texto, áudio e imagem**, qualificação automática e classificação de intenção. Frontend com **rotas deep-linkáveis** (`/conversations/:id` sobrevive ao reload), **suíte de testes** (73 testes — 23 backend + 50 frontend) e **cobertura ≥80%**.
 
 > **Spec do desafio:** [`desafio-tecnico.md`](./desafio-tecnico.md).
 > **Diário de desenvolvimento:** [`DEVELOPMENT_LOG.md`](./DEVELOPMENT_LOG.md) (alimenta o AI Usage Report).
-> **Convenções para agentes:** [`CLAUDE.md`](./CLAUDE.md) e os `CLAUDE.md` por módulo.
+> **Convenções para agentes:** [`CLAUDE.md`](./CLAUDE.md) e os `CLAUDE.md` por módulo (backend, frontend, services, models, hooks, components).
 
 ---
 
@@ -19,6 +19,7 @@ O sistema:
 5. Atualiza dados do lead (nome, empresa, intenção, status `new|qualified|needs_human|opt_out`) automaticamente.
 6. Responde **em texto** (com `quoted` na mensagem original) ou **em áudio** TTS opus (quando o input foi áudio).
 7. Aplica **reactions inteligentes**: 👍 ao receber, ✅ qualified, 👌 opt_out, 🤝 needs_human, ⚠️ erro.
+8. **Frontend hidrata via REST** (`GET /api/conversations`, `/api/leads/{id}`, `/api/whatsapp/connection`) no mount; **Socket.IO mescla deltas** no cache do TanStack Query — F5 mantém a conversa aberta; mensagens novas aparecem em tempo real sem refetch.
 
 ---
 
@@ -36,14 +37,23 @@ O sistema:
 | Cache | Redis 7 (exigido pelo Evolution v2) |
 | Real-time | python-socketio 5.16.x (ASGI root) + socket.io-client 4.8.x |
 | Frontend | Vite 8 + React 19.2 + Tailwind v4 (`@tailwindcss/vite`) + shadcn/ui (OKLCH) |
+| Routing | React Router 7 (`createBrowserRouter`, code splitting) |
+| Server cache | TanStack Query 5 (`useQuery` + `setQueryData` para deltas Socket.IO) |
+| Tests backend | pytest 8 + pytest-asyncio + testcontainers Postgres 16 + httpx ASGITransport |
+| Tests frontend | Vitest 4 + Testing Library 16 + jsdom 29 + axe-core 4 |
 | HTTP | httpx ≥0.27 + tenacity ≥9 |
 
 ---
 
-## Como rodar (Docker Compose)
+## Pré-requisitos
+
+- **Docker Desktop ≥ 24** (única dependência obrigatória — sobe os 5 containers).
+- *(Opcional, para rodar testes localmente sem container)*: **Node ≥ 20** + **uv ≥ 0.5** (`pip install uv`).
+
+## Como rodar em 5 minutos (Docker Compose)
 
 ```bash
-git clone https://github.com/<your-user>/desafio-contact-pro.git
+git clone https://github.com/gasparellodev/desafio-contact-pro.git
 cd desafio-contact-pro
 
 cp .env.example .env
@@ -51,6 +61,7 @@ cp .env.example .env
 #   OPENAI_API_KEY=sk-...                  (obrigatório se AI_PROVIDER=openai e para STT/TTS/vision)
 #   ANTHROPIC_API_KEY=sk-ant-...           (obrigatório se AI_PROVIDER=anthropic)
 #   EVOLUTION_API_KEY=qualquer-string-aqui (será o seu apikey do Evolution)
+#   ADMIN_API_TOKEN=qualquer-string-aqui   (protege endpoints REST + UI; também vai pra VITE_ADMIN_TOKEN)
 #   AI_API_KEY=                            (fallback usado quando faltar a explícita)
 
 docker compose up --build
@@ -68,9 +79,11 @@ Sobem 5 serviços:
 
 Acesse:
 
-- Frontend: <http://localhost:5173>
+- Frontend: <http://localhost:5173> — redireciona para `/conversations`. Deep-links como `/conversations/<uuid>` sobrevivem a reload.
 - Swagger da API: <http://localhost:8000/docs>
-- Health-check: <http://localhost:8000/health>
+- Health-check: <http://localhost:8000/health> — retorna `ok`/`degraded` com status de DB, Redis e Evolution.
+
+Em < 30s após `docker compose up`, todos os 5 containers ficam **healthy**.
 
 ---
 
@@ -127,6 +140,42 @@ docker compose up
 2. `docker compose restart backend`.
 3. A próxima mensagem usa o Claude com `tool_choice` forçado e prompt cache.
 
+### Deep-link e persistência
+
+- Cada conversa tem URL única: `/conversations/<uuid>`.
+- F5 mantém a conversa aberta — frontend recarrega via `GET /api/conversations/{id}/messages` (REST) e Socket.IO reconecta para deltas em tempo real.
+- Mensagens novas aparecem **sem refetch**: backend emite `wa.message.received`, `SocketProvider` chama `queryClient.setQueryData(...)` para mesclar.
+
+---
+
+## Como rodar os testes
+
+A suíte total: **73 testes** (23 backend + 50 frontend) em ~10s combinado.
+
+### Backend (pytest + testcontainers)
+
+```bash
+cd backend
+uv sync                        # instala deps (~10s na 1ª vez)
+uv run pytest tests/ -v        # 23 testes, ~5s (testcontainers spin-up Postgres)
+uv run pytest --cov=app/schemas --cov-report=term-missing   # cobertura dos schemas
+```
+
+> **Requisito:** Docker rodando (testcontainers sobe um Postgres 16-alpine isolado).
+
+### Frontend (Vitest + RTL + axe-core)
+
+```bash
+cd frontend
+npm install                    # ~5s na 1ª vez
+npm run test                   # 50 testes, ~3s
+npm run test:coverage          # 85% statements / 67% branches / 87% functions / 91% lines
+npm run typecheck              # tsc strict
+npm run lint                   # eslint, zero erros
+```
+
+Testes co-located (`Component.test.tsx` ao lado de `Component.tsx`); a11y validada com `axe-core` em componentes críticos (zero violations).
+
 ---
 
 ## Provider/modelo de IA usado
@@ -181,17 +230,32 @@ Resumo no [`docs/decisions.md`](./docs/decisions.md). Os principais:
 
 ---
 
-## Limitações conhecidas (decisões conscientes para o prazo de 6h)
+## Limitações conhecidas (decisões conscientes para o prazo)
 
-- Sem autenticação / login na UI (app local).
+- Sem autenticação de **usuário** (app é admin-only; endpoints exigem `X-Admin-Token`).
 - Apenas **uma instância** WhatsApp por vez.
-- Orchestrator inline, **sem fila assíncrona** (Celery/RQ não cabe em 6h).
+- Orchestrator inline, **sem fila assíncrona** (Celery/RQ ficou fora do prazo).
 - Knowledge base **estática** (sem RAG com embeddings).
-- Sem autorização HMAC/assinatura nos webhooks (Evolution v2 não envia; defesa é `apikey` opcional + rede interna).
-- **Sem testes automatizados** completos (apenas smoke por import e build verificados a cada PR).
+- Sem autorização HMAC/assinatura nos webhooks (Evolution v2 não envia; defesa é `apikey` obrigatório + rede interna).
 - Sem TLS / Nginx / deploy cloud — `docker compose up` é o suficiente.
 - Histórico da IA capado em 12 mensagens (`HISTORY_LIMIT`).
 - `_apply_extracted_to_lead` não sobrescreve campos existentes (lead que muda nome em conversas futuras não atualiza).
+- Cobertura backend (23 testes) cobre os endpoints REST de leitura — orchestrator/AI providers/Evolution client ainda dependem de smoke manual (Spec B do plano cobre isso).
+- E2E cross-stack ainda manual — Playwright fica para Spec C (CI/CD).
+
+---
+
+## Troubleshooting
+
+| Sintoma | Causa | Como resolver |
+|---|---|---|
+| Badge `wa: unknown` no header | Resolvido pelo PR #56 — frontend hidrata via `/api/whatsapp/connection` no mount. Se ainda aparecer, `docker compose restart backend` (o proxy backend → Evolution pode estar fora do ar). | — |
+| QR Code não aparece | Instância já existe (status `connecting`) ou Evolution ainda subindo. Aguarde 30s; clique novamente. Para reset completo, ver "Resetar a sessão WhatsApp". | — |
+| Mensagem não chega no UI | Webhook não configurado. Re-clique "Inicializar instância" (configura webhook idempotente) ou cheque `docker compose logs backend \| grep webhook`. | — |
+| `401 unauthorized` na UI | `ADMIN_API_TOKEN` não preenchido em `.env` ou `VITE_ADMIN_TOKEN` no frontend não bate. Rebuild: `docker compose up -d --build frontend`. | — |
+| `502 evolution unreachable` no console | Evolution está fora do ar. `docker compose ps evolution` e logs. UI degrada para `wa: unknown` (não quebra). | — |
+| Backend não sobe (`Waiting → Recreate → Restarting`) | Conflito de porta. `docker ps` para ver quem usa 8000/5432/6379/8080. Mude `APP_PORT`/`POSTGRES_HOST_PORT`/`REDIS_HOST_PORT` no `.env`. | — |
+| Pytest falha com `cannot connect to Docker` | Docker Desktop não está rodando — testcontainers precisa dele. | — |
 
 ---
 
@@ -199,12 +263,13 @@ Resumo no [`docs/decisions.md`](./docs/decisions.md). Os principais:
 
 - **RAG real** com embeddings da KB Contact Pro (Postgres + pgvector ou Chroma).
 - **Fila assíncrona** (Celery + Redis ou Vercel Queues) para webhooks → workers.
-- **Testes E2E** com pytest + httpx ASGITransport + WebSocket de teste.
+- **Spec B**: suíte completa de testes backend (factories factory-boy, mocks `respx` para Evolution/OpenAI/Anthropic, `fakeredis`, testcontainers já em uso).
+- **Spec C**: CI/CD GitHub Actions (lint + typecheck + pytest + vitest + cobertura) + Playwright cross-stack contra docker-compose real.
 - **Rate limiting** no webhook + assinatura HMAC opcional.
 - **Multi-instância** WhatsApp.
 - **Observabilidade**: Sentry + métricas Prometheus (latência por etapa do pipeline).
 - **Audit log** de todas as ações IA → lead (para review humano).
-- UI: dark mode toggle, virtualização do `MessageList`, busca de conversas.
+- UI: dark mode toggle, virtualização do `MessageList`, busca de conversas, scroll-up infinito de mensagens (`useInfiniteQuery` com cursor `(before, before_id)`).
 - Migrar Evolution para integração direta com Baileys/whatsmeow (cumpre estritamente "biblioteca").
 
 ---
@@ -292,3 +357,10 @@ Resumo no [`docs/decisions.md`](./docs/decisions.md). Os principais:
 - [x] Qualificação de lead + intenção visíveis na UI
 - [x] Reactions inteligentes por status
 - [x] Documentação final + AI Usage Report
+- [x] **Frontend responsivo mobile-first** (Sheet shadcn em mobile/tablet, 3 colunas em desktop)
+- [x] **Persistência de contexto no reload** (URL = fonte da verdade do `activeId` + REST hidrata + Socket.IO mescla)
+- [x] **Suíte de testes** (23 backend pytest + 50 frontend Vitest, 73 total) com cobertura ≥80% statements
+- [x] **A11y validado com axe-core** em componentes críticos (zero violations)
+- [x] **Code splitting por rota** (initial bundle gzip ~125KB)
+- [x] **ErrorBoundary global** com UI de fallback
+- [x] **Workflow de issue → branch → PR → squash merge** com Conventional Commits, atualização de CLAUDE.md e DEVELOPMENT_LOG por PR

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,86 @@
+# Backend — Contact Pro API
+
+API FastAPI + Socket.IO que recebe webhooks da Evolution API, orquestra IA/STT/TTS, persiste no Postgres e emite eventos em tempo real para o frontend.
+
+> Para visão geral do projeto, comandos Docker e setup completo, leia o [`README.md` da raiz](../README.md).
+> Para convenções (rotas, services, models, schemas), leia [`CLAUDE.md`](./CLAUDE.md), [`app/api/CLAUDE.md`](./app/api/CLAUDE.md), [`app/schemas/CLAUDE.md`](./app/schemas/CLAUDE.md), [`app/services/CLAUDE.md`](./app/services/CLAUDE.md), [`app/models/CLAUDE.md`](./app/models/CLAUDE.md).
+
+## Stack
+
+- **Python 3.12** + **FastAPI ≥0.115** + **uvicorn[standard] ≥0.32**.
+- **python-socketio 5.16** (ASGI root: `socketio.ASGIApp(sio, fastapi_app)`).
+- **SQLModel** + **SQLAlchemy[asyncio]** + **asyncpg** + **Alembic** (compare_type=True).
+- **OpenAI ≥1.50** (Whisper, gpt-4o-mini-tts, vision) + **Anthropic ≥0.40** (Claude com prompt cache).
+- **httpx ≥0.27** + **tenacity ≥9** para Evolution client.
+- **uv** como gerenciador de pacotes/lock (`uv sync`).
+- **pytest 8** + **pytest-asyncio** + **testcontainers Postgres 16** + **httpx ASGITransport** para testes.
+
+## Como rodar localmente (sem Docker)
+
+Útil para iterar rápido em endpoints/services. Precisa de Postgres + Redis acessíveis.
+
+```bash
+# Subir só infra:
+docker compose up -d db redis
+
+# Em outro terminal:
+cd backend
+uv sync
+cp ../.env.example .env   # ajuste DATABASE_URL para localhost:<porta-mapeada>
+
+uv run alembic upgrade head
+uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+# Swagger: http://localhost:8000/docs
+# Health:  http://localhost:8000/health
+```
+
+## Como rodar testes
+
+```bash
+cd backend
+uv sync                            # 1ª vez instala testcontainers, pytest, etc.
+uv run pytest tests/ -v            # 23 testes, ~5s
+uv run pytest --cov=app/schemas --cov-report=term-missing
+```
+
+> **Requisito:** Docker rodando (testcontainers sobe um Postgres 16-alpine isolado por sessão pytest). NullPool + engine função-scoped — sem cross-loop pain do pytest-asyncio.
+
+## Estrutura
+
+```
+app/
+  main.py                  # FastAPI + Socket.IO ASGIApp como root
+  core/
+    config.py              # pydantic-settings; get_settings() é fonte única
+    socketio.py            # AsyncServer + emit_global / emit_to_conversation
+  db/
+    session.py             # async engine + SessionLocal + get_session dep
+    base.py                # importa todos os models para SQLModel.metadata
+  models/                  # SQLModel tables (Lead, Conversation, Message + enums)
+  schemas/                 # Pydantic I/O da API (Read/Summary/ListItem/List/Page)
+  api/
+    routes/                # health, webhooks, whatsapp, conversations, leads
+    security.py            # require_admin_token (HMAC compare_digest)
+  services/
+    whatsapp/              # Evolution client + handlers + media
+    ai/                    # provider abstraction (OpenAI/Anthropic via factory)
+    transcription/, tts/, vision/
+    intent_classifier.py
+    lead_qualification.py
+    conversation_orchestrator.py
+  knowledge_base/          # KB Contact Pro
+alembic/                   # migrations (1 inicial: 0001_init_lead_conversation_message)
+tests/                     # pytest async + testcontainers (23 testes hoje)
+```
+
+## Como adicionar...
+
+| O que | Onde | Convenção em |
+|---|---|---|
+| Endpoint REST | `app/api/routes/<nome>.py` + registrar em `app/main.py` | [`app/api/CLAUDE.md`](./app/api/CLAUDE.md) |
+| Pydantic schema | `app/schemas/<nome>.py` (`<X>Read`/`<X>Summary`/`<X>ListItem`/`<X>List`/`<X>Page`) | [`app/schemas/CLAUDE.md`](./app/schemas/CLAUDE.md) |
+| Service | `app/services/<nome>/` | [`app/services/CLAUDE.md`](./app/services/CLAUDE.md) |
+| Model + migration | `app/models/<nome>.py` + `uv run alembic revision --autogenerate -m "..."` | [`app/models/CLAUDE.md`](./app/models/CLAUDE.md) |
+| Teste | `backend/tests/api/test_<nome>.py` (httpx AsyncClient + ASGITransport + testcontainers) | [`CLAUDE.md`](./CLAUDE.md) |
+
+Mais detalhes em [`CLAUDE.md`](./CLAUDE.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,73 @@
-# React + TypeScript + Vite
+# Frontend — Contact Pro Inbox
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Inbox web em tempo real para acompanhar conversas do chatbot WhatsApp + IA. **Responsivo mobile-first**, com **rotas deep-linkáveis** (F5 mantém a conversa aberta), suíte Vitest co-located e a11y validada com axe-core.
 
-Currently, two official plugins are available:
+> Para visão geral do projeto, comandos Docker e setup completo, leia o [`README.md` da raiz](../README.md).
+> Para convenções (componentes, hooks, providers, testes), leia [`CLAUDE.md`](./CLAUDE.md), [`src/components/CLAUDE.md`](./src/components/CLAUDE.md), [`src/hooks/CLAUDE.md`](./src/hooks/CLAUDE.md).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Stack
 
-## React Compiler
+- **Vite 8** + **React 19.2** + **TypeScript 6** strict.
+- **Tailwind v4** via plugin oficial `@tailwindcss/vite` (sem `postcss.config.js`); tokens em **OKLCH** no `src/index.css`.
+- **shadcn/ui** style `new-york`, primitives copiadas em `src/components/ui/`.
+- **React Router 7** (`createBrowserRouter`, lazy routes).
+- **TanStack Query 5** (`useQuery`, cache merge via `setQueryData` quando chega evento Socket.IO).
+- **socket.io-client 4.8.x** (singleton em `src/lib/socket.ts`, `autoConnect: false`).
+- **Vitest 4** + **Testing Library 16** + **jsdom 29** + **axe-core 4**.
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## Scripts
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev            # http://localhost:5173 (host: true)
+npm run build          # tsc -b && vite build (initial gzip ~125KB)
+npm run preview        # serve dist em :5173
+npm run lint           # eslint, zero erros esperados
+npm run typecheck      # tsc -b --noEmit (separado do build)
+npm run test           # vitest run (49 testes em ~4s)
+npm run test:watch     # vitest interativo
+npm run test:ui        # @vitest/ui no browser
+npm run test:coverage  # 85% statements / 67% branches / 87% functions / 91% lines
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Como rodar localmente sem Docker
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Útil para iterar rápido em UI:
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+# Backend precisa estar rodando em http://localhost:8000.
+# Se não tiver, sobe só backend+db+redis+evolution:
+docker compose up -d backend
+
+# Em outro terminal:
+cd frontend
+npm install
+npm run dev
+# Browser http://localhost:5173
 ```
+
+`VITE_API_URL` (default `http://localhost:8000`) e `VITE_ADMIN_TOKEN` (mesmo valor de `ADMIN_API_TOKEN` do backend) podem ser sobrescritos via `.env.local` se precisar.
+
+## Arquitetura local
+
+```
+src/
+  main.tsx                # ErrorBoundary > QueryProvider > SocketProvider > RouterProvider
+  routes/                 # createBrowserRouter + React.lazy code splitting
+  providers/              # QueryProvider, SocketProvider (escreve no cache TanStack ao receber evento)
+  hooks/                  # useConversationsQuery, useConversationMessages, useLead, useWhatsAppConnection
+  components/             # ConversationList, MessageList, MessageBubble, LeadPanel, LeadSheet, QRCodePanel, ErrorBoundary, Skeletons
+  lib/                    # api.ts (typed fetchers), queryKeys.ts, query-client.ts, socket.ts
+  types/                  # contratos Socket.IO + schemas REST
+  test/                   # setup.ts (jest-dom + cleanup), test-utils.tsx (renderWithProviders + runAxe)
+```
+
+## Convenção de testes
+
+- **Co-located**: `Component.test.tsx` ao lado de `Component.tsx`.
+- **Mock de fetch**: `vi.stubGlobal('fetch', vi.fn(...))` no `beforeEach` + `vi.unstubAllGlobals` no `afterEach`.
+- **Mock do socket**: `vi.hoisted(() => ({ fakeSocket }))` antes de `vi.mock('@/lib/socket', () => ({ socket: fakeSocket }))`.
+- **A11y**: `await runAxe(container)` + `expect(result.violations).toEqual([])` em componentes críticos.
+- **Coverage thresholds** em `vitest.config.ts`: 80% statements / 60% branches / 80% functions / 80% lines (rotas excluídas — E2E Spec C cuida).
+
+Mais detalhes em [`CLAUDE.md`](./CLAUDE.md).


### PR DESCRIPTION
# Descrição

Atualiza os 3 READMEs para que um recrutador clone o repo, rode \`docker compose up --build\` e em **< 5 min** tenha o stack completo + saiba como rodar os 73 testes.

Closes #57.

## Tipo

- [ ] feat
- [ ] fix
- [x] chore
- [x] docs (3 READMEs)
- [ ] refactor
- [ ] test
- [ ] perf

## O que muda

### \`README.md\` raiz (366 linhas, +72 vs antes)

- **Visão geral** atualizada com rotas deep-linkáveis, persistência REST+Socket.IO, suíte de 73 testes, cobertura ≥80%.
- **Stack** ganha React Router 7, TanStack Query 5, Vitest 4 + axe-core.
- **Nova seção "Pré-requisitos"** (Docker Desktop ≥24 obrigatório; Node ≥20 + uv ≥0.5 opcional pra rodar testes sem Docker).
- **"Como rodar em 5 minutos"** reformulado, agora com \`ADMIN_API_TOKEN\` explícito (esquecido antes).
- **Nova subseção "Deep-link e persistência"** explicando F5 + REST + Socket.IO mesclando deltas.
- **Nova seção dedicada "Como rodar os testes"** com cmds para backend (\`uv run pytest tests/ -v\` → 23 verdes) e frontend (\`npm run test\` → 49 verdes; \`npm run test:coverage\` → 85/67/87/91).
- **Nova seção "Troubleshooting"** com 7 sintomas mapeados: badge \`wa: unknown\` (resolvido pelo PR #56), QR não aparece, mensagem não chega, 401 unauthorized, 502 evolution, conflito de porta, pytest falha sem Docker.
- **"Limitações"** atualizada: removido "sem testes" e "sem persistência" (agora têm), adicionado "cobertura backend ainda só endpoints de leitura — Spec B cuidará".
- **"O que faria com mais tempo"** menciona Spec B (testes backend completos) e Spec C (CI/CD + Playwright).
- **"Status do desafio"** ganha 7 checkboxes novos: responsivo mobile-first, persistência URL+REST, suíte de testes 73, a11y axe, code splitting, ErrorBoundary, workflow issue/PR/squash merge.

### \`frontend/README.md\` (73 linhas — substitui boilerplate Vite)

- Stack, scripts (\`dev\`/\`build\`/\`lint\`/\`typecheck\`/\`test*\`).
- "Como rodar localmente sem Docker".
- Arquitetura local com mapa do \`src/\`.
- Convenção de testes co-located + mock fetch + mock socket.io via \`vi.hoisted\` + axe + coverage thresholds.

### \`backend/README.md\` (86 linhas — novo)

- Stack.
- "Como rodar localmente sem Docker" (subindo só db+redis+evolution via compose; uvicorn local).
- "Como rodar testes" com requisito Docker para testcontainers.
- Tabela "Como adicionar..." (endpoint/schema/service/model/teste) com links pros CLAUDE.md específicos.

## Checklist obrigatório

- [x] Conventional Commits (\`docs(readme): ...\`)
- [x] CLAUDE.md afetados — N/A: docs apenas
- [x] DEVELOPMENT_LOG.md atualizado
- [x] \`/code-review\` — N/A: docs
- [x] \`/security-review\` — N/A: docs
- [x] Sem secrets no diff
- [x] Smoke test mental do recrutador documentado no DEVELOPMENT_LOG

## Trade-offs

- **READMEs por módulo curtos** (≤90 linhas) — apontam pro README raiz pra setup global e pros CLAUDE.md pra convenções detalhadas. Evita duplicação que envelhece sem aviso.
- **"Resetar a sessão WhatsApp"** continua manual via \`docker volume rm\` (UI de logout fica fora do escopo).