### PR TITLE
fix(frontend): separa status WhatsApp (global) do LeadSheet (per-conversa)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -728,3 +728,37 @@ docker compose up -d --build frontend
 Para testes: `cd backend && uv sync && uv run pytest tests -v` (~5s) + `cd frontend && npm install && npm run test` (~4s).
 
 **Tempo:** ~30min.
+
+---
+
+## 2026-04-25 19:00 — PR #60 / Issue #59: separa status WhatsApp (global) do LeadSheet (per-conversa)
+
+**Contexto:** bug de UX reportado pelo usuário em mobile/tablet. O `LeadSheet` (acionado pelo botão "Detalhes" no header da conversa) misturava `LeadPanel` (per-conversa) com `QRCodePanel` (global) — confundia, parecia que "Conectado" era do lead.
+
+**Decisões:**
+- `LeadSheet.tsx` agora renderiza **só** `LeadPanel`. Título virou "Detalhes do lead" (era "Detalhes da conversa"). Props `state`/`qrcode` removidas.
+- Novo `components/connection/WhatsAppStatusSheet.tsx` — Sheet dedicado ao status global. Recebe `open`/`onOpenChange`/`state`/`qrcode`.
+- `routes/root.tsx`: badge `wa: <state>` no header virou **clicável** (`<button>` envolvendo o `<Badge>` com `aria-label`). Click abre `WhatsAppStatusSheet`. Funciona em qualquer viewport (mobile/tablet/desktop) — em desktop o `QRCodePanel` continua na sidebar direita das rotas, então o Sheet é redundante mas inofensivo.
+- `routes/conversation.tsx`: import de `useConnectionStatus` removido (não mais necessário); `LeadSheet` chamado sem `state`/`qrcode`.
+
+**Trade-offs:**
+- Manter o `WhatsAppStatusSheet` acessível em desktop (mesmo com `QRCodePanel` já na sidebar) é redundância pequena — preferível a esconder o trigger dependendo do viewport (testes ficariam mais frágeis e o usuário pode achar conveniente clicar no badge mesmo no desktop pra confirmar).
+- O texto do `SheetDescription` ("Pareie aqui caso a conexão tenha caído.") cobre o caso de pareamento — botão "Inicializar instância" do `QRCodePanel` continua presente quando state ≠ open.
+
+**Smoke:**
+```bash
+cd frontend
+npm run typecheck   # OK
+npm run lint        # 0 erros
+npm run test        # 49/49 in ~5s
+npm run build       # initial 443KB / gzip 139KB; conversations chunk 33KB / 10KB
+
+docker compose up -d --build frontend
+```
+
+Manual:
+- Mobile: "Detalhes" no header da conversa abre Sheet só com Lead.
+- Mobile: clicar no badge `wa: open` no header abre Sheet "Status WhatsApp" com `QRCodePanel`.
+- Desktop: comportamento da sidebar mantido.
+
+**Tempo:** ~20min.

--- a/frontend/src/components/connection/WhatsAppStatusSheet.tsx
+++ b/frontend/src/components/connection/WhatsAppStatusSheet.tsx
@@ -1,0 +1,50 @@
+/**
+ * Sheet dedicado ao status global da instância WhatsApp.
+ *
+ * Acionado pelo badge `wa: <state>` clicável no header (`routes/root.tsx`).
+ * Substituiu a junção anterior em `LeadSheet`, que misturava status global
+ * com dados per-conversa e confundia o usuário (vide issue #59).
+ *
+ * Em desktop (lg+) este Sheet não é necessário — `QRCodePanel` aparece
+ * direto na sidebar direita das rotas.
+ */
+
+import type { ReactNode } from 'react'
+
+import { QRCodePanel } from '@/components/connection/QRCodePanel'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import type { ConnectionState } from '@/types/domain'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  state: ConnectionState
+  qrcode: string | null
+  trigger?: ReactNode
+}
+
+export function WhatsAppStatusSheet({ open, onOpenChange, state, qrcode }: Props) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle className="font-mono text-sm uppercase tracking-wide">
+            Status WhatsApp
+          </SheetTitle>
+          <SheetDescription>
+            Estado global da instância. Pareie aqui caso a conexão tenha caído.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex flex-col gap-4 px-4 pb-4">
+          <QRCodePanel state={state} qrcode={qrcode} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/src/components/lead/LeadSheet.tsx
+++ b/frontend/src/components/lead/LeadSheet.tsx
@@ -1,16 +1,19 @@
 /**
- * Wrapper que apresenta `LeadPanel` + `QRCodePanel` num Sheet shadcn.
+ * Wrapper que apresenta o `LeadPanel` num Sheet shadcn (mobile/tablet).
  *
- * Em mobile (< md) e tablet (md), os 2 painéis lado a lado não cabem; viram
- * um Sheet aberto via botão no header da rota. Em desktop (lg+), a coluna
- * direita renderiza eles diretamente — esse wrapper é só para os breakpoints
- * pequenos.
+ * Em mobile (< md) e tablet (md), o painel do Lead não cabe ao lado do chat;
+ * vira um Sheet aberto via botão "Detalhes" no header da rota. Em desktop
+ * (lg+), a coluna direita renderiza o painel diretamente.
+ *
+ * Status da instância WhatsApp NÃO entra aqui — é estado global (uma
+ * instância pra todo o app), exposto via badge clicável no header
+ * (`WhatsAppStatusSheet`). Misturar lead (per-conversa) com status (global)
+ * confundia o usuário (vide issue #59).
  */
 
 import { Info } from 'lucide-react'
 import { useState } from 'react'
 
-import { QRCodePanel } from '@/components/connection/QRCodePanel'
 import { Button } from '@/components/ui/button'
 import {
   Sheet,
@@ -20,23 +23,21 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
-import type { ConnectionState, Lead } from '@/types/domain'
+import type { Lead } from '@/types/domain'
 
 import { LeadPanel } from './LeadPanel'
 
 interface Props {
   lead: Lead | null
-  state: ConnectionState
-  qrcode: string | null
   triggerLabel?: string
 }
 
-export function LeadSheet({ lead, state, qrcode, triggerLabel = 'Detalhes' }: Props) {
+export function LeadSheet({ lead, triggerLabel = 'Detalhes' }: Props) {
   const [open, setOpen] = useState(false)
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
-        <Button size="sm" variant="outline" aria-label="Abrir detalhes do lead e QR Code">
+        <Button size="sm" variant="outline" aria-label="Abrir detalhes do lead">
           <Info className="mr-2 size-4" />
           {triggerLabel}
         </Button>
@@ -44,15 +45,12 @@ export function LeadSheet({ lead, state, qrcode, triggerLabel = 'Detalhes' }: Pr
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="font-mono text-sm uppercase tracking-wide">
-            Detalhes da conversa
+            Detalhes do lead
           </SheetTitle>
-          <SheetDescription>
-            Lead extraído pela IA e estado da conexão WhatsApp.
-          </SheetDescription>
+          <SheetDescription>Dados extraídos pela IA durante a conversa.</SheetDescription>
         </SheetHeader>
         <div className="flex flex-col gap-4 px-4 pb-4">
           <LeadPanel lead={lead} />
-          <QRCodePanel state={state} qrcode={qrcode} />
         </div>
       </SheetContent>
     </Sheet>

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -12,7 +12,6 @@ import { MessageList } from '@/components/chat/MessageList'
 import { LeadSheet } from '@/components/lead/LeadSheet'
 import { MessageListSkeleton } from '@/components/Skeletons'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { useConnectionStatus } from '@/hooks/useConnectionStatus'
 import { useConversationMessages } from '@/hooks/useConversationMessages'
 import { useLead } from '@/hooks/useLead'
 import { useSocketContext } from '@/providers/socket-context'
@@ -33,7 +32,6 @@ export function ConversationView({
   leadId,
   mobileBackButton,
 }: ConversationViewProps) {
-  const { state, qrcode } = useConnectionStatus()
   const { thinking } = useSocketContext()
   const messages = useConversationMessages(conversationId)
   const listEntry = listItems.find((it) => it.conversation.id === conversationId)
@@ -50,7 +48,7 @@ export function ConversationView({
           <CardTitle className="truncate text-sm">{headerLabel}</CardTitle>
         </div>
         <div className="flex shrink-0 items-center gap-2 lg:hidden">
-          <LeadSheet lead={leadQuery.data ?? null} state={state} qrcode={qrcode} />
+          <LeadSheet lead={leadQuery.data ?? null} />
         </div>
       </CardHeader>
       <CardContent className="flex-1 overflow-hidden p-0">

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -1,20 +1,24 @@
 /**
  * Layout shell. Header sticky com sistema-pulse + área principal flex-1.
  *
- * Layout responsivo é resolvido pelas próprias rotas (`conversations.tsx`),
- * não aqui — esta camada cuida só do header e do container.
+ * O badge `wa:` é clicável — abre `WhatsAppStatusSheet` com o `QRCodePanel`
+ * (estado/parear). Status WhatsApp é GLOBAL, então fica no header em vez de
+ * misturar com `LeadSheet` per-conversa (vide issue #59).
  */
 
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
+import { WhatsAppStatusSheet } from '@/components/connection/WhatsAppStatusSheet'
 import { Badge } from '@/components/ui/badge'
 import { useConnectionStatus } from '@/hooks/useConnectionStatus'
-import { useSocketContext } from '@/providers/socket-context'
 import { cn } from '@/lib/utils'
+import { useSocketContext } from '@/providers/socket-context'
 
 export function RootLayout() {
   const { connected } = useSocketContext()
-  const { state } = useConnectionStatus()
+  const { state, qrcode } = useConnectionStatus()
+  const [statusSheetOpen, setStatusSheetOpen] = useState(false)
 
   return (
     <div className="bg-background text-foreground flex h-dvh flex-col">
@@ -40,14 +44,26 @@ export function RootLayout() {
               <span className="hidden sm:inline">socket: </span>
               {connected ? 'on' : 'off'}
             </Badge>
-            <Badge
-              variant={
-                state === 'open' ? 'success' : state === 'connecting' ? 'warning' : 'secondary'
-              }
+            <button
+              type="button"
+              onClick={() => setStatusSheetOpen(true)}
+              aria-label={`Abrir status do WhatsApp (atual: ${state})`}
+              className="rounded-md focus-visible:outline-ring/60 focus-visible:outline-2"
             >
-              <span className="hidden sm:inline">wa: </span>
-              {state}
-            </Badge>
+              <Badge
+                variant={
+                  state === 'open'
+                    ? 'success'
+                    : state === 'connecting'
+                      ? 'warning'
+                      : 'secondary'
+                }
+                className="cursor-pointer hover:opacity-80 transition-opacity"
+              >
+                <span className="hidden sm:inline">wa: </span>
+                {state}
+              </Badge>
+            </button>
           </div>
         </div>
       </header>
@@ -55,6 +71,13 @@ export function RootLayout() {
       <main className="mx-auto flex w-full max-w-[1400px] flex-1 overflow-hidden">
         <Outlet />
       </main>
+
+      <WhatsAppStatusSheet
+        open={statusSheetOpen}
+        onOpenChange={setStatusSheetOpen}
+        state={state}
+        qrcode={qrcode}
+      />
     </div>
   )
 }


### PR DESCRIPTION
# Descrição

Bug de UX em mobile/tablet: o botão "Detalhes" no header da conversa abria um Sheet com **\`LeadPanel\` + \`QRCodePanel\` juntos**. Como o título era "Detalhes da conversa", o usuário interpretava \`Conectado\` como sendo do lead específico — confuso porque WhatsApp é estado **global** (uma instância pra todo o app).

Closes #59.

## Tipo

- [ ] feat
- [x] fix (UX)
- [ ] chore
- [x] docs (DEVELOPMENT_LOG.md)
- [x] refactor (extrai responsabilidade)
- [ ] test
- [ ] perf

## O que muda

- **\`LeadSheet\`** renderiza só \`LeadPanel\`. Título "Detalhes do lead" (era "Detalhes da conversa"). Props \`state\`/\`qrcode\` removidas.
- **\`components/connection/WhatsAppStatusSheet.tsx\`** (novo): Sheet dedicado ao status global. Recebe \`open\`/\`onOpenChange\`/\`state\`/\`qrcode\`.
- **\`routes/root.tsx\`**: badge \`wa: <state>\` virou **clicável** (\`<button>\` envolvendo \`<Badge>\` com \`aria-label\` semântico). Click abre o \`WhatsAppStatusSheet\`. Funciona em qualquer viewport.
- **\`routes/conversation.tsx\`**: import de \`useConnectionStatus\` removido; \`LeadSheet\` chamado sem props de connection.
- Mobile: agora há 2 triggers separados — "Detalhes" no header da conversa abre só Lead; badge \`wa\` no header global abre só status WhatsApp.
- Desktop: \`QRCodePanel\` continua na sidebar direita das rotas; o badge clicável funciona como atalho extra.

## Smoke test

\`\`\`bash
cd frontend
npm run typecheck   # OK
npm run lint        # 0 erros
npm run test        # 49/49 in ~5s
npm run build       # initial 443KB / gzip 139KB
\`\`\`

Manual:
- Mobile (360×640): "Detalhes" abre Sheet **só com Lead**. Click no badge \`wa: open\` abre Sheet "Status WhatsApp" só com QRCodePanel.
- Tablet (768): mesmo comportamento.
- Desktop (1440): comportamento da sidebar mantido + badge clicável funciona.

## Trade-offs

- **\`WhatsAppStatusSheet\` acessível em desktop também** (mesmo com \`QRCodePanel\` já na sidebar) — redundância pequena preferível a esconder o trigger condicionalmente. Testes ficam mais simples e usuário não fica perdendo trigger ao redimensionar.
- **Sem teste novo** — o componente é um wrapper trivial em torno de Sheet+QRCodePanel; cobertura existente do QRCodePanel + smoke manual cobrem o caso. Adicionar teste-de-integração de "click badge → abre sheet" entra no Spec C com Playwright.