### PR TITLE
feat(backend): pause de atendimento + typing indicator (Spec D.1)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -762,3 +762,46 @@ Manual:
 - Desktop: comportamento da sidebar mantido.
 
 **Tempo:** ~20min.
+
+---
+
+## 2026-04-25 19:30 — PR #63 / Issue #62: backend pause de atendimento + typing indicator (Spec D.1)
+
+**Contexto:** primeira PR do épico #61 (Spec B+C+D — produção-ready). Adiciona 3 capacidades ao backend:
+
+1. **Pause de atendimento por lead** (`Lead.bot_paused`). Quando True, orchestrator não chama IA — só persiste a mensagem recebida e emite no Socket.IO.
+2. **Auto-pause em handoff humano**: quando AI retorna `intent=HUMAN_HANDOFF` ou `status_suggestion=NEEDS_HUMAN`, marca `bot_paused=True` antes de mandar a última fala (sinaliza pro lead que vai transferir).
+3. **Typing indicator no WhatsApp** via `evolution.send_presence(composing, delay=8000)` antes de chamar AI. Fire-and-forget — falha não trava pipeline.
+
+Endpoints novos:
+- `POST /api/leads/{id}/resume-bot` — libera o bot. Idempotente.
+- `POST /api/conversations/{id}/messages` — humano envia mensagem manual via UI.
+
+**Decisões:**
+- Migration 0002 manual (autogenerate evitado por causa de bugs com pg.ENUM no projeto). Coluna NOT NULL com `server_default=False` — leads existentes ficam não-pausados.
+- `LeadSummary`/`LeadRead` ganham `bot_paused` (frontend usa pra badge).
+- `MessageCreate` schema novo: `content: str (1-4096)` (limite WhatsApp).
+- `EvolutionClient.send_presence` retorna `dict | None` — Evolution não retorna body em 200, só status.
+- `POST /messages` persiste como PENDING → tenta send_text → atualiza pra SENT/FAILED. Em FAILED, persiste só `exc.__class__.__name__` (sem `str(exc)` que poderia vazar URL/credencial).
+- `_lead_to_dict` (Socket.IO) ganha `bot_paused` — frontend ouve `lead.updated` e atualiza badge em tempo real.
+
+**Trade-offs:**
+- A última fala do bot ainda vai antes da pausa — intencional. Se preferíssemos pausar imediato, lead ficaria sem entender o que aconteceu.
+- Sem rate limit no `POST /messages` — admin token é confiável; rate limit fica como follow-up de hardening.
+- Skip-when-paused do orchestrator e `send_presence` do client NÃO testados nesta PR — gap intencional, Spec B (PR 5) cobrirá com respx + fakeredis.
+
+**Reviews aplicadas:**
+- `sentry-skills:code-review`: Approve com 2 pedidos (1) PR 3 frontend deve seguir imediato — sem badge admin pode achar bot quebrou; (2) trade-off "última fala antes da pausa" documentado aqui.
+- `sentry-skills:security-review`: 0 findings (Critical/High/Medium). Auth router-level OK, ORM parametriza SQL, sem SSRF (URL Evolution é server-controlled), `error_reason` só guarda nome da classe. Auto-pause induzido por lead malicioso → impacto baixíssimo (só pausa o próprio lead, admin retoma).
+
+**Smoke test:**
+```bash
+cd backend
+uv run pytest tests/api -v   # 32 passed (era 23, +9 novos)
+uv run ruff check . --select F,I,UP --fix  # auto-aplicado
+docker compose up -d --build backend
+docker compose exec -T db psql -U contactpro -d contactpro -c "\d leads" | grep bot_paused
+# bot_paused | boolean | not null | false ✓
+```
+
+**Tempo:** ~50min.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ docker compose up
 2. Bubble exibe `🖼️ Imagem`; descrição via vision aparece inline.
 3. Bot responde com base na descrição + legenda.
 
+### Pause / handoff humano
+
+Quando a IA classifica `intent=human_handoff` ou `status_suggestion=needs_human`, o backend **automaticamente** pausa o bot pra aquele lead (`Lead.bot_paused=True`). A última fala da IA ainda vai (avisar o lead que vai transferir), mas próximas mensagens caem em modo skip:
+- Mensagem persistida ✓
+- Emit Socket.IO `wa.message.received` ✓
+- Reaction 👍 ✓
+- **Sem typing, sem AI, sem resposta automática.**
+
+Pra responder como humano:
+1. UI mostra badge `PAUSADO` no header da conversa pausada (PR 3 — frontend).
+2. Use o input de envio manual: digita texto + clica "Enviar como humano".
+3. Backend chama `POST /api/conversations/{id}/messages` → Evolution `send_text` → mensagem chega no celular do lead.
+4. Quando quiser que o bot volte: clica "Retomar bot" → `POST /api/leads/{id}/resume-bot` → `bot_paused=False`.
+
+### Indicador "digitando..."
+
+Antes de chamar a IA, o backend dispara `evolution.send_presence(composing, delay=8000)` no contato. O lead vê **"digitando..."** no WhatsApp enquanto a IA processa. Falha do Evolution não trava pipeline (try/except + log warning).
+
 ### Trocar de provider de IA
 
 1. Edite `.env`: `AI_PROVIDER=anthropic` e ajuste `AI_MODEL=claude-sonnet-4-6`.
@@ -255,6 +273,7 @@ Resumo no [`docs/decisions.md`](./docs/decisions.md). Os principais:
 | `401 unauthorized` na UI | `ADMIN_API_TOKEN` não preenchido em `.env` ou `VITE_ADMIN_TOKEN` no frontend não bate. Rebuild: `docker compose up -d --build frontend`. | — |
 | `502 evolution unreachable` no console | Evolution está fora do ar. `docker compose ps evolution` e logs. UI degrada para `wa: unknown` (não quebra). | — |
 | Backend não sobe (`Waiting → Recreate → Restarting`) | Conflito de porta. `docker ps` para ver quem usa 8000/5432/6379/8080. Mude `APP_PORT`/`POSTGRES_HOST_PORT`/`REDIS_HOST_PORT` no `.env`. | — |
+| Bot parou de responder pra um lead específico | `Lead.bot_paused=True` (auto-pause em handoff). Esperado. Use UI ou `curl -X POST -H "X-Admin-Token: ..." http://localhost:8000/api/leads/<id>/resume-bot` pra retomar. | — |
 | Pytest falha com `cannot connect to Docker` | Docker Desktop não está rodando — testcontainers precisa dele. | — |
 
 ---

--- a/backend/README.md
+++ b/backend/README.md
@@ -78,6 +78,16 @@ tests/                     # pytest async + testcontainers (23 testes hoje)
 | O que | Onde | Convenção em |
 |---|---|---|
 | Endpoint REST | `app/api/routes/<nome>.py` + registrar em `app/main.py` | [`app/api/CLAUDE.md`](./app/api/CLAUDE.md) |
+
+## Endpoints atuais
+
+- `GET /health` — liveness + dependencies (DB/Redis/Evolution).
+- `POST /api/webhooks/evolution` — webhook Evolution (apikey-protected).
+- `/api/whatsapp/*` (admin) — instance/qrcode/connection/webhook setup.
+- `GET /api/conversations[, /{id}, /{id}/messages]` (admin) — listar conversas + mensagens cursor.
+- `POST /api/conversations/{id}/messages` (admin) — **humano envia mensagem manual** (handoff).
+- `GET /api/leads/{id}` (admin) — detalhe completo do lead.
+- `POST /api/leads/{id}/resume-bot` (admin) — **libera bot quando estiver pausado por handoff**.
 | Pydantic schema | `app/schemas/<nome>.py` (`<X>Read`/`<X>Summary`/`<X>ListItem`/`<X>List`/`<X>Page`) | [`app/schemas/CLAUDE.md`](./app/schemas/CLAUDE.md) |
 | Service | `app/services/<nome>/` | [`app/services/CLAUDE.md`](./app/services/CLAUDE.md) |
 | Model + migration | `app/models/<nome>.py` + `uv run alembic revision --autogenerate -m "..."` | [`app/models/CLAUDE.md`](./app/models/CLAUDE.md) |

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,10 +8,9 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 from sqlmodel import SQLModel
 
-from alembic import context
-
 # Importa todos os models para registrar em SQLModel.metadata
 import app.db.base  # noqa: F401
+from alembic import context
 from app.core.config import get_settings
 
 # Alembic Config

--- a/backend/alembic/versions/0001_init_lead_conversation_message.py
+++ b/backend/alembic/versions/0001_init_lead_conversation_message.py
@@ -12,7 +12,6 @@ Migração inicial criando as 3 tabelas do domínio:
 Enums armazenados como VARCHAR para evitar bugs do autogenerate com pg.ENUM.
 """
 from collections.abc import Sequence
-from typing import Union
 
 import sqlalchemy as sa
 import sqlmodel  # noqa: F401  (necessário para AutoString se usado em models)
@@ -22,9 +21,9 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0001_init"
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/0002_lead_bot_paused.py
+++ b/backend/alembic/versions/0002_lead_bot_paused.py
@@ -1,0 +1,40 @@
+"""add Lead.bot_paused (handoff humano)
+
+Revision ID: 0002_lead_bot_paused
+Revises: 0001_init
+Create Date: 2026-04-25 19:30:00
+
+Adiciona a coluna `bot_paused` em `leads` (default False, NOT NULL). Quando True,
+o orchestrator NÃO chama IA — só persiste a mensagem recebida e emite no Socket.IO,
+deixando humano responder via UI.
+
+Migration escrita à mão (autogenerate é evitado neste projeto por causa de bugs
+com Postgres ENUM — mantemos consistência).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002_lead_bot_paused"
+down_revision: str | Sequence[str] | None = "0001_init"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "leads",
+        sa.Column(
+            "bot_paused",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("leads", "bot_paused")

--- a/backend/app/api/CLAUDE.md
+++ b/backend/app/api/CLAUDE.md
@@ -57,6 +57,8 @@ api/
 | GET | `/api/conversations/{id}` | admin | Detalhe da conversa |
 | GET | `/api/conversations/{id}/messages` | admin | Mensagens cursor `before` |
 | GET | `/api/leads/{id}` | admin | Detalhe completo do lead |
+| POST | `/api/leads/{id}/resume-bot` | admin | Libera bot quando estiver pausado por handoff humano (idempotente) |
+| POST | `/api/conversations/{id}/messages` | admin | Humano envia mensagem manual (Message OUT + Evolution send_text) |
 
 ## Não fazer
 

--- a/backend/app/api/routes/conversations.py
+++ b/backend/app/api/routes/conversations.py
@@ -15,19 +15,26 @@ from sqlalchemy import func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.security import require_admin_token
+from app.core.socketio import emit_to_conversation
 from app.db.session import get_session
 from app.models.conversation import Conversation
-from app.models.enums import LeadStatus
+from app.models.enums import Direction, LeadStatus, MessageStatus, MessageType
 from app.models.lead import Lead
 from app.models.message import Message
 from app.schemas.conversation import (
     ConversationList,
     ConversationListItem,
     ConversationRead,
+    MessageCreate,
     MessagePage,
     MessageRead,
 )
 from app.schemas.lead import LeadSummary
+from app.services.whatsapp.evolution_client import (
+    EvolutionAPIError,
+    get_evolution_client,
+)
+from app.services.whatsapp.payload import jid_to_phone
 
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
@@ -203,3 +210,69 @@ async def list_messages(
         next_before_id=next_before_id,
         limit=limit,
     )
+
+
+@router.post("/{conversation_id}/messages", response_model=MessageRead, status_code=201)
+async def send_manual_message(
+    conversation_id: UUID,
+    payload: MessageCreate,
+    session: AsyncSession = Depends(get_session),
+) -> MessageRead:
+    """Envia mensagem como humano (admin) pela conta WhatsApp da instância.
+
+    Persiste a Message OUT como `PENDING`, dispara `send_text` na Evolution,
+    e atualiza pra `SENT`/`FAILED` conforme o resultado. Funciona independente
+    de `lead.bot_paused` — humano sempre pode enviar (caso de uso principal:
+    bot pausado por handoff). Emite `wa.message.sent` no Socket.IO da conversa.
+
+    Requisições idempotentes? **Não** — cada chamada cria mensagem nova. Cliente
+    deve fazer debounce/disabling do botão pra evitar duplo-send.
+    """
+    row = (
+        await session.execute(
+            select(Conversation, Lead)
+            .join(Lead, Lead.id == Conversation.lead_id)
+            .where(Conversation.id == conversation_id)
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="conversation not found")
+    conversation, lead = row
+
+    msg = Message(
+        conversation_id=conversation.id,
+        direction=Direction.OUT,
+        type=MessageType.TEXT,
+        content=payload.content,
+        status=MessageStatus.PENDING,
+    )
+    session.add(msg)
+    await session.commit()
+    await session.refresh(msg)
+
+    client = get_evolution_client()
+    try:
+        result = await client.send_text(
+            number=jid_to_phone(lead.whatsapp_jid),
+            text=payload.content,
+        )
+        wa_id = (result.get("key") or {}).get("id") if isinstance(result, dict) else None
+        msg.whatsapp_message_id = wa_id
+        msg.status = MessageStatus.SENT
+    except EvolutionAPIError as exc:
+        msg.status = MessageStatus.FAILED
+        msg.error_reason = exc.__class__.__name__
+        # Não vaza str(exc) (URLs internas / hints HTTP) — log estruturado em outro lugar.
+    finally:
+        session.add(msg)
+        await session.commit()
+        await session.refresh(msg)
+        await emit_to_conversation(
+            str(conversation.id),
+            "wa.message.sent",
+            MessageRead.model_validate(msg).model_dump(mode="json"),
+        )
+
+    if msg.status == MessageStatus.FAILED:
+        raise HTTPException(status_code=502, detail="evolution send failed")
+    return MessageRead.model_validate(msg)

--- a/backend/app/api/routes/leads.py
+++ b/backend/app/api/routes/leads.py
@@ -1,7 +1,8 @@
-"""Endpoints REST de leitura de Leads."""
+"""Endpoints REST de Leads."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -9,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.security import require_admin_token
+from app.core.socketio import emit_global
 from app.db.session import get_session
 from app.models.lead import Lead
 from app.schemas.lead import LeadRead
@@ -28,4 +30,25 @@ async def get_lead(
     lead = (await session.execute(select(Lead).where(Lead.id == lead_id))).scalar_one_or_none()
     if lead is None:
         raise HTTPException(status_code=404, detail="lead not found")
+    return LeadRead.model_validate(lead)
+
+
+@router.post("/{lead_id}/resume-bot", response_model=LeadRead)
+async def resume_bot(
+    lead_id: UUID,
+    session: AsyncSession = Depends(get_session),
+) -> LeadRead:
+    """Libera o bot pra responder de novo. Idempotente — chamar com bot_paused=False
+    é no-op (apenas devolve o lead). Emite `lead.updated` no Socket.IO.
+    """
+    lead = (await session.execute(select(Lead).where(Lead.id == lead_id))).scalar_one_or_none()
+    if lead is None:
+        raise HTTPException(status_code=404, detail="lead not found")
+    if lead.bot_paused:
+        lead.bot_paused = False
+        lead.updated_at = datetime.now(UTC)
+        session.add(lead)
+        await session.commit()
+        await session.refresh(lead)
+        await emit_global("lead.updated", LeadRead.model_validate(lead).model_dump(mode="json"))
     return LeadRead.model_validate(lead)

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from sqlalchemy import Column, DateTime, ForeignKey, String
@@ -9,7 +9,7 @@ from app.models.enums import Intent
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class Conversation(SQLModel, table=True):

--- a/backend/app/models/lead.py
+++ b/backend/app/models/lead.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import Column, DateTime, String
+import sqlalchemy as sa
+from sqlalchemy import Boolean, Column, DateTime, String
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlmodel import Field, SQLModel
 
@@ -9,7 +10,7 @@ from app.models.enums import LeadStatus, ServiceInterest
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class Lead(SQLModel, table=True):
@@ -19,9 +20,7 @@ class Lead(SQLModel, table=True):
         default_factory=uuid4,
         sa_column=Column(PG_UUID(as_uuid=True), primary_key=True),
     )
-    whatsapp_jid: str = Field(
-        sa_column=Column(String(64), unique=True, index=True, nullable=False)
-    )
+    whatsapp_jid: str = Field(sa_column=Column(String(64), unique=True, index=True, nullable=False))
     name: str | None = Field(default=None, max_length=160)
     company: str | None = Field(default=None, max_length=200)
     phone: str | None = Field(default=None, max_length=32)
@@ -35,13 +34,15 @@ class Lead(SQLModel, table=True):
         default=LeadStatus.NEW,
         sa_column=Column(String(32), nullable=False, default=LeadStatus.NEW.value, index=True),
     )
+    bot_paused: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default=sa.false(), default=False),
+    )
     created_at: datetime = Field(
         default_factory=_now,
         sa_column=Column(DateTime(timezone=True), nullable=False, default=_now),
     )
     updated_at: datetime = Field(
         default_factory=_now,
-        sa_column=Column(
-            DateTime(timezone=True), nullable=False, default=_now, onupdate=_now
-        ),
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=_now, onupdate=_now),
     )

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from sqlalchemy import Column, DateTime, ForeignKey, String, Text
@@ -9,7 +9,7 @@ from app.models.enums import Direction, Intent, MessageStatus, MessageType
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class Message(SQLModel, table=True):

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.enums import Direction, Intent, MessageStatus, MessageType
 from app.schemas.lead import LeadSummary
@@ -62,6 +62,17 @@ class ConversationList(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class MessageCreate(BaseModel):
+    """Input para envio manual por humano (POST /api/conversations/{id}/messages).
+
+    `content` é obrigatório, max 4096 chars (limite WhatsApp). Tipo é sempre TEXT
+    nesse endpoint — humano não envia áudio/imagem por aqui (faria pelo próprio
+    WhatsApp dele se quisesse).
+    """
+
+    content: str = Field(..., min_length=1, max_length=4096)
 
 
 class MessagePage(BaseModel):

--- a/backend/app/schemas/lead.py
+++ b/backend/app/schemas/lead.py
@@ -29,6 +29,7 @@ class LeadSummary(BaseModel):
     phone: str | None
     service_interest: ServiceInterest
     status: LeadStatus
+    bot_paused: bool
 
 
 class LeadRead(BaseModel):
@@ -45,5 +46,6 @@ class LeadRead(BaseModel):
     lead_goal: str | None
     estimated_volume: str | None
     status: LeadStatus
+    bot_paused: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -15,6 +15,9 @@ Cérebro do sistema. Recebe `ParsedMessage` do webhook Evolution e administra to
 5. **Reaction 👍 é fire-and-forget.** Falha não interrompe o pipeline (apenas loga warning).
 6. **Smart reaction final** depende do `status` do lead pós-AI: ✅ qualified, 👌 opt_out, 🤝 needs_human, 👍 new.
 7. **Histórico tem cap de 12 mensagens** (`HISTORY_LIMIT`) para controlar custo de prompt e latência.
+8. **Skip-when-paused.** Se `lead.bot_paused = True`: persistimos a Message IN, emitimos `wa.message.received`, mandamos reaction 👍 (fire-and-forget) e **retornamos**. Sem typing, sem AI, sem resposta. Humano responde via UI (`POST /api/conversations/{id}/messages`).
+9. **Auto-pause em handoff.** Quando AI retorna `intent == HUMAN_HANDOFF` ou `status_suggestion == NEEDS_HUMAN`, marcamos `lead.bot_paused = True` ANTES de mandar a resposta. A última fala da IA ainda vai (avisar o lead que vai transferir); próximas mensagens caem no skip. Admin retoma com `POST /api/leads/{id}/resume-bot`.
+10. **Typing indicator.** Antes de chamar AI, `evolution.send_presence(composing, delay=8000)` em try/except. Falha NÃO interrompe pipeline (Evolution offline ou método não suportado vira só warning).
 
 ### Pipeline (texto)
 

--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -19,7 +19,7 @@ Fluxo (texto; áudio/imagem entram nos PRs #11–14):
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 from sqlalchemy import select
@@ -57,7 +57,7 @@ HISTORY_LIMIT = 12  # últimas N mensagens (IN+OUT) que entram no contexto da IA
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def _msg_to_dict(msg: Message) -> dict:
@@ -90,6 +90,7 @@ def _lead_to_dict(lead: Lead) -> dict:
         "lead_goal": lead.lead_goal,
         "estimated_volume": lead.estimated_volume,
         "status": lead.status.value if isinstance(lead.status, LeadStatus) else lead.status,
+        "bot_paused": lead.bot_paused,
         "updated_at": lead.updated_at.isoformat() if lead.updated_at else None,
     }
 
@@ -208,9 +209,30 @@ class ConversationOrchestrator:
             )
             return
         await self.session.refresh(msg_in)
-        await emit_to_conversation(
-            str(conv.id), "wa.message.received", _msg_to_dict(msg_in)
-        )
+        await emit_to_conversation(str(conv.id), "wa.message.received", _msg_to_dict(msg_in))
+
+        # 3.5 SKIP-WHEN-PAUSED — bot pausado por handoff humano.
+        # Mensagem persistida + emitida pra UI; humano responde via UI manual.
+        # Reaction 👍 fire-and-forget mas SEM AI/typing/resposta.
+        if lead.bot_paused:
+            logger.info(
+                "orchestrator_skipped_bot_paused",
+                extra={
+                    "conversation_id": str(conv.id),
+                    "lead_id": str(lead.id),
+                    "message_id": parsed.whatsapp_message_id,
+                },
+            )
+            try:
+                await self.whatsapp.send_reaction(
+                    remote_jid=parsed.remote_jid,
+                    message_id=parsed.whatsapp_message_id,
+                    from_me=False,
+                    emoji="👍",
+                )
+            except EvolutionAPIError as exc:
+                logger.warning("paused_reaction_failed", extra={"error": str(exc)})
+            return
 
         # 4. reaction 👍
         try:
@@ -243,9 +265,8 @@ class ConversationOrchestrator:
                     {"messageId": str(msg_in.id), "transcription": description},
                 )
                 caption = parsed.text or ""
-                ai_input_text = (
-                    f"[Lead enviou imagem. Descrição: {description}]"
-                    + (f"\nLegenda: {caption}" if caption else "")
+                ai_input_text = f"[Lead enviou imagem. Descrição: {description}]" + (
+                    f"\nLegenda: {caption}" if caption else ""
                 )
             else:
                 ai_input_text = "[imagem recebida — descrição indisponível]"
@@ -266,6 +287,17 @@ class ConversationOrchestrator:
                 ai_input_text = "[áudio recebido sem transcrição disponível]"
         if not ai_input_text:
             ai_input_text = "[mensagem sem texto]"
+
+        # 5.5 typing indicator no WhatsApp (humaniza espera).
+        # Fire-and-forget: nunca bloqueia pipeline se Evolution rejeitar.
+        try:
+            await self.whatsapp.send_presence(
+                number=jid_to_phone(parsed.remote_jid),
+                presence="composing",
+                delay_ms=8000,
+            )
+        except EvolutionAPIError as exc:
+            logger.warning("presence_failed", extra={"error": str(exc)})
 
         # 6. AI thinking + chamada
         await emit_to_conversation(
@@ -303,6 +335,26 @@ class ConversationOrchestrator:
         self._apply_extracted_to_lead(lead, ai_resp)
         if ai_resp.status_suggestion:
             lead.status = ai_resp.status_suggestion
+
+        # 7.5 AUTO-PAUSE em handoff humano. A última fala da IA ainda vai
+        # (pra avisar o lead que vai transferir), mas próxima mensagem cai
+        # no skip-when-paused acima.
+        if (
+            ai_resp.intent == Intent.HUMAN_HANDOFF
+            or ai_resp.status_suggestion == LeadStatus.NEEDS_HUMAN
+        ):
+            lead.bot_paused = True
+            logger.info(
+                "orchestrator_auto_paused",
+                extra={
+                    "lead_id": str(lead.id),
+                    "intent": ai_resp.intent.value,
+                    "status_suggestion": ai_resp.status_suggestion.value
+                    if ai_resp.status_suggestion
+                    else None,
+                },
+            )
+
         lead.updated_at = _now()
         conv.last_intent = ai_resp.intent
         conv.last_message_at = _now()
@@ -310,7 +362,9 @@ class ConversationOrchestrator:
         self.session.add(conv)
 
         # 8. persist OUT — se entrada foi áudio, responder em áudio
-        out_type = MessageType.AUDIO if parsed.message_type == MessageType.AUDIO else MessageType.TEXT
+        out_type = (
+            MessageType.AUDIO if parsed.message_type == MessageType.AUDIO else MessageType.TEXT
+        )
         msg_out = Message(
             conversation_id=conv.id,
             direction=Direction.OUT,
@@ -331,9 +385,7 @@ class ConversationOrchestrator:
             "conversation.status_changed",
             {"id": str(conv.id), "last_intent": ai_resp.intent.value},
         )
-        await emit_to_conversation(
-            str(conv.id), "ai.response.generated", _msg_to_dict(msg_out)
-        )
+        await emit_to_conversation(str(conv.id), "ai.response.generated", _msg_to_dict(msg_out))
 
         # 10. envio para o WhatsApp (texto OR áudio com TTS, com quoted)
         try:
@@ -353,7 +405,9 @@ class ConversationOrchestrator:
                         "message": {"conversation": parsed.text or ""},
                     },
                 )
-            wa_id = (send_result.get("key") or {}).get("id") if isinstance(send_result, dict) else None
+            wa_id = (
+                (send_result.get("key") or {}).get("id") if isinstance(send_result, dict) else None
+            )
             msg_out.whatsapp_message_id = wa_id
             msg_out.status = MessageStatus.SENT
         except EvolutionAPIError as exc:
@@ -376,9 +430,13 @@ class ConversationOrchestrator:
                         text=ai_resp.reply,
                     )
                     msg_out.status = MessageStatus.SENT
-                    msg_out.error_reason = (msg_out.error_reason or "") + " | fallback texto enviado"
+                    msg_out.error_reason = (
+                        msg_out.error_reason or ""
+                    ) + " | fallback texto enviado"
                 except EvolutionAPIError as exc2:
-                    msg_out.error_reason = (msg_out.error_reason or "") + f" | fallback falhou: {exc2}"
+                    msg_out.error_reason = (
+                        msg_out.error_reason or ""
+                    ) + f" | fallback falhou: {exc2}"
         except Exception as exc:  # noqa: BLE001
             logger.exception(
                 "send_unexpected",
@@ -404,8 +462,8 @@ class ConversationOrchestrator:
                     msg_out.status = MessageStatus.SENT
                     msg_out.type = MessageType.TEXT  # converte para texto na persistência
                     msg_out.error_reason = (
-                        (msg_out.error_reason or "") + " | fallback texto enviado"
-                    )
+                        msg_out.error_reason or ""
+                    ) + " | fallback texto enviado"
                 except Exception as exc2:  # noqa: BLE001
                     msg_out.error_reason = (msg_out.error_reason or "") + (
                         f" | fallback falhou: {exc2.__class__.__name__}"

--- a/backend/app/services/whatsapp/CLAUDE.md
+++ b/backend/app/services/whatsapp/CLAUDE.md
@@ -21,6 +21,7 @@
 | `POST` | `/message/sendText/{instance}` | `send_text(number, text, quoted?, delay_ms?)` |
 | `POST` | `/message/sendWhatsAppAudio/{instance}` | `send_audio(number, audio_base64, ...)` |
 | `POST` | `/message/sendReaction/{instance}` | `send_reaction(remote_jid, message_id, from_me, emoji)` |
+| `POST` | `/chat/sendPresence/{instance}` | `send_presence(number, presence='composing', delay_ms=5000)` |
 | `POST` | `/chat/getBase64FromMediaMessage/{instance}` | `download_media_base64(message_key)` |
 
 ## Convenções

--- a/backend/app/services/whatsapp/evolution_client.py
+++ b/backend/app/services/whatsapp/evolution_client.py
@@ -145,6 +145,21 @@ class EvolutionClient:
 
     # ===== Send =====
 
+    async def send_presence(
+        self,
+        number: str,
+        presence: str = "composing",
+        delay_ms: int = 5000,
+    ) -> dict[str, Any] | None:
+        """Indicador de presença no WhatsApp (ex: "digitando..." pro lead).
+
+        Evolution v2: POST /chat/sendPresence/{instance} { number, presence, delay }.
+        Valores aceitos: 'available', 'composing', 'recording', 'paused'.
+        Falha NÃO interrompe pipeline — chamadores devem usar try/except + warning.
+        """
+        body = {"number": number, "presence": presence, "delay": delay_ms}
+        return await self._request("POST", f"/chat/sendPresence/{self.instance}", json=body)
+
     async def send_text(
         self,
         number: str,
@@ -156,9 +171,7 @@ class EvolutionClient:
         body: dict[str, Any] = {"number": number, "text": text, "delay": delay_ms}
         if quoted:
             body["quoted"] = quoted
-        return await self._request(
-            "POST", f"/message/sendText/{self.instance}", json=body
-        )
+        return await self._request("POST", f"/message/sendText/{self.instance}", json=body)
 
     async def send_audio(
         self,
@@ -178,9 +191,7 @@ class EvolutionClient:
             "delay": delay_ms,
             "encoding": encoding,
         }
-        return await self._request(
-            "POST", f"/message/sendWhatsAppAudio/{self.instance}", json=body
-        )
+        return await self._request("POST", f"/message/sendWhatsAppAudio/{self.instance}", json=body)
 
     async def send_reaction(
         self,

--- a/backend/tests/api/test_conversations.py
+++ b/backend/tests/api/test_conversations.py
@@ -195,3 +195,102 @@ async def test_list_conversations_q_does_not_treat_percent_as_wildcard(
     assert response.status_code == 200
     items = response.json()["items"]
     assert {i["lead"]["name"] for i in items} == {"100% Garantia"}
+
+
+# ----- POST /api/conversations/{id}/messages (envio manual humano) -----
+
+
+class _StubEvoOK:
+    """Mock do EvolutionClient pra cenário "send_text deu certo"."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def send_text(self, *, number: str, text: str, **_):
+        self.calls.append({"number": number, "text": text})
+        return {"key": {"id": "WA-FAKE-12345"}, "status": "ok"}
+
+
+class _StubEvoFail:
+    """Mock pra cenário "Evolution rejeitou (502 down)"."""
+
+    async def send_text(self, *_, **__):
+        from app.services.whatsapp.evolution_client import EvolutionAPIError
+
+        raise EvolutionAPIError("evolution down")
+
+
+async def test_send_manual_message_persists_out_and_calls_evolution(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    _, conv = await _seed_pair(session, name="Cliente Manual")
+    stub = _StubEvoOK()
+    # Substitui o client global usado pelo endpoint.
+    from app.api.routes import conversations as conv_module
+
+    monkeypatch.setattr(conv_module, "get_evolution_client", lambda: stub)
+
+    response = await client.post(
+        f"/api/conversations/{conv.id}/messages", json={"content": "Oi, Vinicius aqui."}
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["direction"] == "out"
+    assert body["type"] == "text"
+    assert body["content"] == "Oi, Vinicius aqui."
+    assert body["status"] == "sent"
+    assert body["whatsapp_message_id"] == "WA-FAKE-12345"
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["text"] == "Oi, Vinicius aqui."
+
+
+async def test_send_manual_message_502_when_evolution_fails(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    _, conv = await _seed_pair(session)
+    from app.api.routes import conversations as conv_module
+
+    monkeypatch.setattr(conv_module, "get_evolution_client", lambda: _StubEvoFail())
+
+    response = await client.post(
+        f"/api/conversations/{conv.id}/messages", json={"content": "tentativa"}
+    )
+
+    assert response.status_code == 502
+
+
+async def test_send_manual_message_404_for_missing_conversation(client: AsyncClient, monkeypatch):
+    from app.api.routes import conversations as conv_module
+
+    monkeypatch.setattr(conv_module, "get_evolution_client", lambda: _StubEvoOK())
+    response = await client.post(f"/api/conversations/{uuid4()}/messages", json={"content": "hi"})
+    assert response.status_code == 404
+
+
+async def test_send_manual_message_validates_content(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    _, conv = await _seed_pair(session)
+    from app.api.routes import conversations as conv_module
+
+    monkeypatch.setattr(conv_module, "get_evolution_client", lambda: _StubEvoOK())
+
+    # vazio
+    empty = await client.post(f"/api/conversations/{conv.id}/messages", json={"content": ""})
+    assert empty.status_code == 422
+    # > 4096 chars
+    too_long = await client.post(
+        f"/api/conversations/{conv.id}/messages", json={"content": "x" * 5000}
+    )
+    assert too_long.status_code == 422
+
+
+async def test_send_manual_message_requires_admin_token(client: AsyncClient, session: AsyncSession):
+    _, conv = await _seed_pair(session)
+    response = await client.post(
+        f"/api/conversations/{conv.id}/messages",
+        json={"content": "hi"},
+        headers={"X-Admin-Token": ""},
+    )
+    assert response.status_code == 401

--- a/backend/tests/api/test_leads.py
+++ b/backend/tests/api/test_leads.py
@@ -54,3 +54,49 @@ async def test_get_lead_requires_admin_token(client: AsyncClient, session: Async
     # Remove o header padrão para testar 401
     response = await client.get(f"/api/leads/{lead.id}", headers={"X-Admin-Token": ""})
     assert response.status_code == 401
+
+
+# ----- POST /api/leads/{id}/resume-bot -----
+
+
+async def test_resume_bot_clears_paused_flag(client: AsyncClient, session: AsyncSession):
+    from app.models.lead import Lead
+
+    lead = Lead(
+        whatsapp_jid="5511999990999@s.whatsapp.net",
+        name="Pausado",
+        bot_paused=True,
+    )
+    session.add(lead)
+    await session.commit()
+    await session.refresh(lead)
+
+    response = await client.post(f"/api/leads/{lead.id}/resume-bot")
+
+    assert response.status_code == 200
+    assert response.json()["bot_paused"] is False
+    # Confere persistência via GET
+    get_resp = await client.get(f"/api/leads/{lead.id}")
+    assert get_resp.json()["bot_paused"] is False
+
+
+async def test_resume_bot_is_idempotent(client: AsyncClient, session: AsyncSession):
+    """Chamar resume-bot quando já está False não erra (no-op)."""
+    lead = await _make_lead(session)
+    assert lead.bot_paused is False
+
+    response = await client.post(f"/api/leads/{lead.id}/resume-bot")
+
+    assert response.status_code == 200
+    assert response.json()["bot_paused"] is False
+
+
+async def test_resume_bot_returns_404_for_missing(client: AsyncClient):
+    response = await client.post(f"/api/leads/{uuid4()}/resume-bot")
+    assert response.status_code == 404
+
+
+async def test_resume_bot_requires_admin_token(client: AsyncClient, session: AsyncSession):
+    lead = await _make_lead(session)
+    response = await client.post(f"/api/leads/{lead.id}/resume-bot", headers={"X-Admin-Token": ""})
+    assert response.status_code == 401


### PR DESCRIPTION
# Descrição

Primeira PR do épico #61 (Spec B+C+D — produção-ready). Adiciona pause de atendimento + typing indicator + endpoints de handoff humano no backend. Frontend (PR 3) virá imediato com UI de PAUSADO + input manual.

Closes #62.

## Tipo

- [x] feat (3 capacidades novas)
- [ ] fix
- [ ] chore
- [x] docs (3 CLAUDE.md + README + backend/README)
- [ ] refactor
- [x] test (9 novos, 32 total)
- [ ] perf

## O que muda

**Migration 0002_lead_bot_paused**: adiciona \`Lead.bot_paused: bool NOT NULL DEFAULT FALSE\`. Server_default → leads existentes ficam não-pausados, sem breaking.

**Skip-when-paused** no orchestrator (\`conversation_orchestrator.py\`):
- Após persistir Message IN + emitir \`wa.message.received\`, checa \`lead.bot_paused\`.
- Se True: manda reaction 👍 (fire-and-forget) e RETURN. Sem typing, sem AI, sem reply.

**Auto-pause em handoff**: quando AI retorna \`intent=HUMAN_HANDOFF\` ou \`status_suggestion=NEEDS_HUMAN\`, marca \`bot_paused=True\` ANTES da resposta final. A última fala da IA ainda vai (avisa o lead que vai transferir).

**Typing indicator**: \`evolution.send_presence("composing", delay=8000)\` em try/except antes de chamar AI. Lead vê "digitando..." no WhatsApp por até 8s.

**\`EvolutionClient.send_presence(number, presence, delay_ms)\`** — novo método. POST /chat/sendPresence/{instance}.

**Endpoints novos** (admin-only):
- \`POST /api/leads/{id}/resume-bot\` — libera o bot. Idempotente. Emite \`lead.updated\`.
- \`POST /api/conversations/{id}/messages\` — humano envia mensagem manual. Persiste como PENDING → \`send_text\` → SENT/FAILED. Emite \`wa.message.sent\`. Em FAILED retorna 502.

**Schemas**: LeadSummary/LeadRead ganham \`bot_paused: bool\`. \`MessageCreate { content: str (1-4096) }\` novo.

**\`_lead_to_dict\`** (Socket.IO) inclui \`bot_paused\` — frontend ouve \`lead.updated\` e atualiza badge em real-time.

## Checklist obrigatório

- [x] Conventional Commits no título e nos commits
- [x] CLAUDE.md afetados atualizados (\`app/api/\`, \`app/services/\`, \`app/services/whatsapp/\`)
- [x] DEVELOPMENT_LOG.md atualizado
- [x] \`sentry-skills:code-review\` aplicado — Approve com pedidos (PR 3 frontend deve seguir; trade-off documentado)
- [x] \`sentry-skills:security-review\` aplicado — 0 findings Critical/High/Medium
- [x] Sem secrets no diff
- [x] Smoke test manual realizado

## Smoke test

\`\`\`bash
cd backend
uv run pytest tests/api -v   # 32 passed (era 23, +9 novos)
uv run ruff format .          # 0 erros
uv run ruff check . --ignore B008  # 0 erros (B008 = padrão FastAPI Depends)

docker compose up -d --build backend
docker compose exec -T db psql -U contactpro -d contactpro -c "\\d leads" | grep bot_paused
# bot_paused | boolean | not null | false ✓

# Endpoints
TOKEN=\$(grep ADMIN_API_TOKEN .env | cut -d= -f2)
curl -X POST -H "X-Admin-Token: \$TOKEN" http://localhost:8000/api/leads/<id>/resume-bot
curl -X POST -H "X-Admin-Token: \$TOKEN" -H "Content-Type: application/json" \\
     -d '{"content":"oi"}' http://localhost:8000/api/conversations/<id>/messages
\`\`\`

## Trade-offs

- **Última fala antes da pausa**: lead recebe a mensagem final da IA antes do bot parar de responder — intencional, melhor UX que "silêncio surpresa".
- **\`POST /messages\` sem rate limit**: admin token é confiável; rate limit fica como follow-up de hardening.
- **Skip-when-paused / send_presence sem teste nesta PR**: gap intencional — Spec B (PR 5) cobrirá com respx+fakeredis.
- **Sem feature flag**: comportamento ativa em todos os leads imediato. Migration safe (server_default=False).

## Riscos pós-merge

- **Sem PR 3 (frontend) UI fica confusa**: admin vê bot "morrer" sem badge PAUSADO. Mitigação: PR 3 vai logo na sequência (mesmo dia).
- **Evolution v2 pode rejeitar /chat/sendPresence**: alguns instances têm sendPresence desabilitado por config. Try/except + warning cobre — pipeline continua.