### PR TITLE
chore(env): simplifica setup pro recrutador (debounce hardcoded, .env minimal)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,62 +1,53 @@
-# ===== AI provider switch =====
-AI_PROVIDER=openai                 # openai | anthropic
-AI_MODEL=gpt-4o-mini               # ou claude-sonnet-4-6 quando AI_PROVIDER=anthropic
-AI_API_KEY=                        # fallback usado pelo provider ativo
-OPENAI_API_KEY=                    # usado também por STT/TTS/vision
-ANTHROPIC_API_KEY=                 # quando AI_PROVIDER=anthropic
+# ============================================================================
+# Setup mínimo: edite SÓ as 4 chaves abaixo. O resto já tem default funcional
+# pro Docker Compose. NUNCA committar este arquivo com valores reais — o
+# .env (gitignored) é onde os secrets ficam.
+# ============================================================================
 
-# ===== STT =====
-STT_PROVIDER=openai
-STT_MODEL=whisper-1
-STT_API_KEY=
+# ---- 1) IA (escolha 1 dos 2 providers) ----
+AI_PROVIDER=openai                       # openai | anthropic
+OPENAI_API_KEY=                          # OBRIGATÓRIO se AI_PROVIDER=openai (também usado por STT/TTS/vision)
+ANTHROPIC_API_KEY=                       # OBRIGATÓRIO se AI_PROVIDER=anthropic
 
-# ===== TTS =====
-TTS_PROVIDER=openai
-TTS_MODEL=gpt-4o-mini-tts
-TTS_VOICE=alloy
-TTS_FORMAT=opus                    # PTT nativo do WhatsApp
-TTS_API_KEY=
+# ---- 2) WhatsApp (Evolution) — sua "senha" da instância ----
+EVOLUTION_API_KEY=change-me-on-first-run
 
-# ===== Vision =====
-VISION_ENABLED=true
-VISION_MODEL=gpt-4o-mini
+# ---- 3) Admin token (UI exige) — use a MESMA string nos dois ----
+ADMIN_API_TOKEN=change-me-admin-token
+VITE_ADMIN_TOKEN=change-me-admin-token
 
-# ===== Database (asyncpg) =====
+# ============================================================================
+# Vars internas com defaults (não precisa mexer; redeclare aqui se quiser
+# override sem editar docker-compose.yml).
+# ============================================================================
+
+# AI / IA
+AI_MODEL=gpt-4o-mini                     # ou claude-sonnet-4-6 quando AI_PROVIDER=anthropic
+
+# Database (asyncpg). Backend precisa explícito; o EVOLUTION_DATABASE_URI vai
+# pra container Evolution e usa schema separado no MESMO Postgres.
 DATABASE_URL=postgresql+asyncpg://contactpro:contactpro@db:5432/contactpro
 POSTGRES_USER=contactpro
 POSTGRES_PASSWORD=contactpro
 POSTGRES_DB=contactpro
 
-# ===== Redis (exigido pelo Evolution v2) =====
+# Redis
 REDIS_URL=redis://redis:6379
 
-# Buffer de mensagens consecutivas (Spec D.2). Lead manda 3 mensagens em <
-# N segundos → 1 só processamento de IA (concatena texto, single AI call).
-# 0 desliga o buffer (modo legacy: cada mensagem processada imediato).
-MESSAGE_BUFFER_DEBOUNCE_SECONDS=5
-
-# ===== Evolution API v2.3.7 =====
+# Evolution API (defaults internos do compose — só preencha se mudar a infra)
 EVOLUTION_API_URL=http://evolution:8080
-EVOLUTION_API_KEY=change-me-on-first-run
 EVOLUTION_INSTANCE=contactpro
 EVOLUTION_WEBHOOK_URL=http://backend:8000/api/webhooks/evolution
 EVOLUTION_DATABASE_PROVIDER=postgresql
 EVOLUTION_DATABASE_URI=postgresql://contactpro:contactpro@db:5432/contactpro?schema=evolution_api
 EVOLUTION_CACHE_REDIS_URI=redis://redis:6379/6
-EVOLUTION_CACHE_REDIS_PREFIX=evolution
 
-# ===== App =====
+# App
 APP_PORT=8000
 FRONTEND_PORT=5173
 LOG_LEVEL=INFO
 SOCKET_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
-# ===== Admin auth (rotas /api/whatsapp/*) =====
-# Token obrigatório para acionar setup da instância e ler QR Code.
-# Frontend recebe via VITE_ADMIN_TOKEN (build-time) e envia em X-Admin-Token.
-ADMIN_API_TOKEN=change-me-admin-token
-VITE_ADMIN_TOKEN=change-me-admin-token
-
-# ===== Portas na host (override quando 5432 / 6379 já estão em uso) =====
-POSTGRES_HOST_PORT=5432
-REDIS_HOST_PORT=6379
+# (opcional) Override de portas: descomente se 5432/6379 já estão em uso
+# POSTGRES_HOST_PORT=5433
+# REDIS_HOST_PORT=6380

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ git clone https://github.com/gasparellodev/desafio-contact-pro.git
 cd desafio-contact-pro
 
 cp .env.example .env
-# Edite .env e preencha pelo menos:
-#   OPENAI_API_KEY=sk-...                  (obrigatório se AI_PROVIDER=openai e para STT/TTS/vision)
+# Edite .env e preencha SÓ as 4 chaves do bloco "Setup mínimo":
+#   OPENAI_API_KEY=sk-...                  (obrigatório se AI_PROVIDER=openai; também usado por STT/TTS/vision)
 #   ANTHROPIC_API_KEY=sk-ant-...           (obrigatório se AI_PROVIDER=anthropic)
-#   EVOLUTION_API_KEY=qualquer-string-aqui (será o seu apikey do Evolution)
-#   ADMIN_API_TOKEN=qualquer-string-aqui   (protege endpoints REST + UI; também vai pra VITE_ADMIN_TOKEN)
-#   AI_API_KEY=                            (fallback usado quando faltar a explícita)
+#   EVOLUTION_API_KEY=qualquer-string-aqui (sua "senha" da instância Evolution)
+#   ADMIN_API_TOKEN + VITE_ADMIN_TOKEN     (a MESMA string nos dois — protege endpoints + UI)
+# Tudo o resto tem default funcional pro Docker; só override se precisar.
 
 docker compose up --build
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -97,7 +97,7 @@ Lifespan do FastAPI agenda `asyncio.create_task(buffer_worker(...))` no startup.
 2. Para cada deadline expirado: `LRANGE` + `DEL` atômico → callback `process_pending(conv_id, [msg_ids])`.
 3. Cancelado no shutdown via `task.cancel()`.
 
-`MESSAGE_BUFFER_DEBOUNCE_SECONDS=0` no `.env` desliga o worker (modo legacy: webhook processa síncrono). Útil em testes unitários.
+Debounce hardcoded em `services/message_buffer.DEBOUNCE_SECONDS = 5` (sem env var pra reduzir superfície de config). Pra mudar, edite a constante.
 | Pydantic schema | `app/schemas/<nome>.py` (`<X>Read`/`<X>Summary`/`<X>ListItem`/`<X>List`/`<X>Page`) | [`app/schemas/CLAUDE.md`](./app/schemas/CLAUDE.md) |
 | Service | `app/services/<nome>/` | [`app/services/CLAUDE.md`](./app/services/CLAUDE.md) |
 | Model + migration | `app/models/<nome>.py` + `uv run alembic revision --autogenerate -m "..."` | [`app/models/CLAUDE.md`](./app/models/CLAUDE.md) |

--- a/backend/app/api/routes/webhooks.py
+++ b/backend/app/api/routes/webhooks.py
@@ -114,7 +114,6 @@ async def evolution_webhook(
                 redis_client,
                 conversation_id=str(msg.conversation_id),
                 message_id=str(msg.id),
-                debounce_seconds=settings.message_buffer_debounce_seconds,
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,11 +47,6 @@ class Settings(BaseSettings):
     # ===== Redis =====
     redis_url: str = "redis://redis:6379"
 
-    # ===== Message buffer (debounce de mensagens consecutivas) =====
-    # Lead manda 3 mensagens em < N segundos → 1 só processamento de IA.
-    # Reduz custo + dá contexto agregado pra resposta. 0 = desliga buffer.
-    message_buffer_debounce_seconds: int = Field(default=5, ge=0, le=60)
-
     # ===== Evolution API =====
     evolution_api_url: str = "http://evolution:8080"
     evolution_api_key: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,18 +33,13 @@ async def _process_batch_callback(conversation_id: str, message_ids: list[str]) 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     configure_logging()
-    # Worker do buffer Redis (D.2). Só sobe se debounce > 0; em testes
-    # unitários (debounce=0) o webhook processa síncrono.
-    worker_task: asyncio.Task | None = None
-    if settings.message_buffer_debounce_seconds > 0:
-        redis_client = get_redis()
-        worker_task = asyncio.create_task(
-            buffer_worker(redis_client, process_batch=_process_batch_callback)
-        )
-        logger.info(
-            "buffer_worker_scheduled",
-            extra={"debounce_seconds": settings.message_buffer_debounce_seconds},
-        )
+    # Worker do buffer Redis (D.2). Debounce hardcoded em
+    # `services/message_buffer.DEBOUNCE_SECONDS` (5s).
+    redis_client = get_redis()
+    worker_task: asyncio.Task | None = asyncio.create_task(
+        buffer_worker(redis_client, process_batch=_process_batch_callback)
+    )
+    logger.info("buffer_worker_scheduled")
     try:
         yield
     finally:

--- a/backend/app/services/message_buffer.py
+++ b/backend/app/services/message_buffer.py
@@ -39,13 +39,18 @@ BUFFER_KEY = "buffer:conv:{conv_id}"
 DEADLINE_KEY = "buffer-deadline:conv:{conv_id}"
 DEADLINE_TTL_SECONDS = 60  # safety net contra leak se DEL falhar
 
+# Debounce hardcoded — 5s é o sweet-spot pra WhatsApp (lead mandando texto
+# rápido em sequência). Não exposto como env var pra reduzir superfície de
+# config no setup do recrutador. Se precisar ajustar, edite aqui.
+DEBOUNCE_SECONDS = 5
+
 
 async def enqueue(
     redis: Redis,
     *,
     conversation_id: str,
     message_id: str,
-    debounce_seconds: int = 5,
+    debounce_seconds: int = DEBOUNCE_SECONDS,
 ) -> None:
     """Adiciona message_id ao buffer da conversa e (re)agenda processamento.
 


### PR DESCRIPTION
Closes #66. Setup mínimo: 4 chaves obrigatórias no .env (era 7+). DEBOUNCE_SECONDS hardcoded em `services/message_buffer.py`. Sem defaults com credenciais no compose (segurança). 32 testes verdes.