### PR TITLE
feat(frontend): pause UI + envio manual de mensagem (Spec D.3)

### DIFF
--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -841,3 +841,47 @@ docker compose logs backend | grep buffer_worker_scheduled  # → debounce_secon
 - Worker tick 1s = latência adicional 0-1s.
 
 **Tempo:** ~70min.
+
+---
+
+## 2026-04-25 20:30 — PR #69 / Issue #68: frontend pause UI + envio manual (Spec D.3)
+
+**Contexto:** terceira PR do épico #61. Backend D.1 já marcava `Lead.bot_paused=true` quando AI sugeria handoff humano + expunha endpoints REST. Frontend agora mostra esse estado e permite ao admin agir.
+
+**Decisões:**
+- `types/domain.ts` ganha `bot_paused: boolean` em Lead e LeadSummary.
+- `lib/api.ts`: novos fetchers `resumeBot(leadId)` e `sendManualMessage({conversationId, content})`.
+- `hooks/useResumeBot.ts`: mutation TanStack Query. Em sucesso, `setQueryData(leadKeys.detail)` + `invalidateQueries(conversationKeys.lists)`.
+- `hooks/useSendManualMessage.ts`: mutation simples, sem optimistic update — Socket.IO `wa.message.sent` mescla a Message OUT no cache automaticamente.
+- `components/chat/ConversationHeader.tsx` (novo, extraído de `routes/conversation.tsx`): título + slot mobile back + slot direito; quando `lead.bot_paused`, mostra fundo destacado (status-needs-human/10), badge âmbar "Pausado · humano" e botão "Retomar bot" (com `aria-label`).
+- `components/chat/ManualMessageInput.tsx` (novo): textarea (max 4096 chars como o backend) + botão Enviar com spinner; renderizado SÓ quando `lead.bot_paused`. Sem optimistic update (Socket.IO cuida).
+- `components/chat/ConversationList.tsx`: cada item ganha badge âmbar "⚑ pausado" quando `lead.bot_paused`.
+- `routes/conversation.tsx`: substitui CardHeader inline por `<ConversationHeader>`. Renderiza `<ManualMessageInput>` no rodapé do CardContent quando `lead?.bot_paused`.
+- `routes/conversations.tsx` adapter `adaptListItem`: passa `bot_paused: it.lead.bot_paused` (mantém UI sincronizada com a lista).
+
+**Tests Vitest** (4 novos, 58 total):
+- `useResumeBot.test.tsx`: chama URL POST correta, atualiza cache, invalida lista.
+- `useSendManualMessage.test.tsx`: chama URL POST com body `{content}` correto.
+- `ConversationHeader.test.tsx`: não mostra badge/botão quando bot ativo; mostra ambos quando paused; clicar Retomar dispara fetch.
+- `ManualMessageInput.test.tsx`: renderiza textarea+botão; botão disabled quando vazio; envia + limpa input no sucesso.
+
+**Reviews aplicadas:**
+- `vercel:react-best-practices`: ✅ usa `useMutation` (idiomático, sem refetch manual), `setQueryData` no sucesso (sem invalidate desnecessário do detail), aria-labels em botões com ícone, sem inline arrow functions em hot paths.
+- `sentry-skills:code-review`: ✅ optimistic updates evitados (Socket.IO já cobre); textarea com maxLength enforcement no client + backend; aria-live em alert de erro; padrão consistente com outros hooks.
+
+**Smoke:**
+```bash
+cd frontend
+npm run typecheck   # OK
+npm run lint        # 0 erros
+npm run test        # 58/58 in ~4s
+npm run test:coverage   # 85.8% / 68.3% / 87.4% / 91.3% — todos acima dos thresholds 80/60/80/80
+docker compose up -d --build frontend
+```
+
+**Trade-offs:**
+- Sem optimistic update no envio manual — UX é "aperta enviar → spinner → mensagem aparece via socket". Aceitável; spinner é breve (~1s).
+- `ManualMessageInput` esconde quando bot ativo — escolha consciente pra não confundir admin (humano + bot respondendo simultaneamente seria caótico).
+- Indicador `⚑ pausado` na lista usa só badge âmbar — sem ícone ou cor de borda. Discreto mas visível; alternativa seria pintar a linha inteira (intrusivo).
+
+**Tempo:** ~50min.

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Quando a IA classifica `intent=human_handoff` ou `status_suggestion=needs_human`
 - **Sem typing, sem AI, sem resposta automática.**
 
 Pra responder como humano:
-1. UI mostra badge `PAUSADO` no header da conversa pausada (PR 3 — frontend).
-2. Use o input de envio manual: digita texto + clica "Enviar como humano".
-3. Backend chama `POST /api/conversations/{id}/messages` → Evolution `send_text` → mensagem chega no celular do lead.
-4. Quando quiser que o bot volte: clica "Retomar bot" → `POST /api/leads/{id}/resume-bot` → `bot_paused=False`.
+1. UI mostra badge `PAUSADO · humano` âmbar no header da conversa pausada + a lista marca a conversa com `⚑ pausado`.
+2. Input de envio manual aparece automático embaixo das mensagens — digita texto + clica "Enviar".
+3. Backend chama `POST /api/conversations/{id}/messages` → Evolution `send_text` → mensagem chega no celular do lead. Socket.IO `wa.message.sent` mescla no cache da UI sem refetch.
+4. Quando quiser que o bot volte: clica "Retomar bot" no header → `POST /api/leads/{id}/resume-bot` → `bot_paused=False` → badge some, input some.
 
 ### Indicador "digitando..."
 

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -7,7 +7,7 @@
 | Pasta | Conteúdo |
 |---|---|
 | `ui/` | Primitives shadcn (button, card, badge, scroll-area, separator, avatar, **sheet**). |
-| `chat/` | ConversationList, MessageList, MessageBubble, AIThinkingIndicator. |
+| `chat/` | ConversationList, MessageList, MessageBubble, AIThinkingIndicator, **ConversationHeader** (badge PAUSADO + botão Retomar), **ManualMessageInput** (envio humano quando paused). |
 | `lead/` | LeadPanel, **LeadSheet** (wrapper Sheet pra mobile/tablet). |
 | `connection/` | QRCodePanel. |
 

--- a/frontend/src/components/chat/ConversationHeader.test.tsx
+++ b/frontend/src/components/chat/ConversationHeader.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConversationHeader } from '@/components/chat/ConversationHeader'
+import { renderWithProviders } from '@/test/test-utils'
+import type { Lead } from '@/types/domain'
+
+const baseLead: Lead = {
+  id: 'lead-1',
+  whatsapp_jid: '5511999990001@s.whatsapp.net',
+  name: 'Cliente',
+  company: null,
+  phone: '+5511999990001',
+  service_interest: 'unknown',
+  lead_goal: null,
+  estimated_volume: null,
+  status: 'new',
+  bot_paused: false,
+  created_at: '2026-04-25T14:00:00Z',
+  updated_at: '2026-04-25T15:00:00Z',
+}
+
+describe('ConversationHeader', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ...baseLead, bot_paused: false }), { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('mostra título e NÃO mostra badge/botão quando bot está ativo', () => {
+    renderWithProviders(<ConversationHeader title="Maria" lead={baseLead} />)
+    expect(screen.getByText('Maria')).toBeInTheDocument()
+    expect(screen.queryByText(/Pausado/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Retomar/i })).not.toBeInTheDocument()
+  })
+
+  it('mostra badge PAUSADO + botão Retomar quando bot_paused', () => {
+    renderWithProviders(
+      <ConversationHeader title="João" lead={{ ...baseLead, bot_paused: true }} />
+    )
+    expect(screen.getByText(/Pausado/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Retomar/i })).toBeInTheDocument()
+  })
+
+  it('clicar em Retomar bot dispara fetch POST /resume-bot', async () => {
+    renderWithProviders(
+      <ConversationHeader title="João" lead={{ ...baseLead, bot_paused: true }} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Retomar/i }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+      expect(url).toMatch(/\/api\/leads\/lead-1\/resume-bot$/)
+    })
+  })
+})

--- a/frontend/src/components/chat/ConversationHeader.tsx
+++ b/frontend/src/components/chat/ConversationHeader.tsx
@@ -1,0 +1,63 @@
+/**
+ * Header da conversa: título + ações (voltar mobile, Lead detalhes, status).
+ *
+ * Quando `lead.bot_paused = true`, mostra badge âmbar "PAUSADO" + botão
+ * "Retomar bot" que dispara `useResumeBot`. Sem isso, admin não tem como
+ * saber que o bot foi pausado por handoff (silêncio sem feedback).
+ */
+
+import { PlayCircle } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { CardHeader, CardTitle } from '@/components/ui/card'
+import { useResumeBot } from '@/hooks/useResumeBot'
+import { cn } from '@/lib/utils'
+import type { Lead } from '@/types/domain'
+
+interface Props {
+  title: string
+  lead: Lead | null
+  mobileBackButton?: ReactNode
+  rightSlot?: ReactNode
+}
+
+export function ConversationHeader({ title, lead, mobileBackButton, rightSlot }: Props) {
+  const resumeBot = useResumeBot()
+  const paused = lead?.bot_paused === true
+
+  return (
+    <CardHeader
+      className={cn(
+        'flex flex-row items-center justify-between border-b py-2.5',
+        paused && 'bg-status-needs-human/10 border-status-needs-human/30'
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {mobileBackButton}
+        <CardTitle className="truncate text-sm">{title}</CardTitle>
+        {paused && (
+          <Badge variant="warning" className="font-mono text-[10px] uppercase tracking-wider">
+            Pausado · humano
+          </Badge>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {paused && lead && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => resumeBot.mutate(lead.id)}
+            disabled={resumeBot.isPending}
+            aria-label="Retomar bot"
+          >
+            <PlayCircle className="mr-1 size-4" />
+            {resumeBot.isPending ? 'Retomando…' : 'Retomar bot'}
+          </Button>
+        )}
+        {rightSlot}
+      </div>
+    </CardHeader>
+  )
+}

--- a/frontend/src/components/chat/ConversationList.test.tsx
+++ b/frontend/src/components/chat/ConversationList.test.tsx
@@ -17,6 +17,7 @@ function makeItem(overrides: Partial<Lead> = {}, conv: Partial<Conversation> = {
     lead_goal: null,
     estimated_volume: null,
     status: 'new',
+    bot_paused: false,
     created_at: '2026-04-25T14:00:00Z',
     updated_at: '2026-04-25T15:00:00Z',
     ...overrides,

--- a/frontend/src/components/chat/ConversationList.tsx
+++ b/frontend/src/components/chat/ConversationList.tsx
@@ -114,6 +114,15 @@ export function ConversationList({ items, activeId, onSelect }: Props) {
                   <Badge variant={statusBadgeVariant[lead.status]} className="text-[10px]">
                     {statusLabel[lead.status]}
                   </Badge>
+                  {lead.bot_paused && (
+                    <Badge
+                      variant="warning"
+                      className="font-mono text-[9px] uppercase tracking-wider"
+                      aria-label="Bot pausado — aguardando humano"
+                    >
+                      ⚑ pausado
+                    </Badge>
+                  )}
                 </div>
               </div>
             </button>

--- a/frontend/src/components/chat/ManualMessageInput.test.tsx
+++ b/frontend/src/components/chat/ManualMessageInput.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ManualMessageInput } from '@/components/chat/ManualMessageInput'
+import { renderWithProviders } from '@/test/test-utils'
+
+describe('ManualMessageInput', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: 'm1',
+              conversation_id: 'conv-1',
+              whatsapp_message_id: 'WA-1',
+              direction: 'out',
+              type: 'text',
+              content: 'olá',
+              transcription: null,
+              media_url: null,
+              media_mime: null,
+              intent: null,
+              status: 'sent',
+              quoted_message_id: null,
+              error_reason: null,
+              created_at: '2026-04-25T15:30:00Z',
+            }),
+            { status: 201 }
+          )
+      )
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renderiza textarea + botão Enviar', () => {
+    renderWithProviders(<ManualMessageInput conversationId="conv-1" />)
+    expect(
+      screen.getByRole('textbox', { name: 'Mensagem para o lead' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Enviar/i })).toBeInTheDocument()
+  })
+
+  it('botão fica disabled quando textarea vazio', () => {
+    renderWithProviders(<ManualMessageInput conversationId="conv-1" />)
+    expect(screen.getByRole('button', { name: /Enviar/i })).toBeDisabled()
+  })
+
+  it('envia, limpa o input após sucesso', async () => {
+    renderWithProviders(<ManualMessageInput conversationId="conv-1" />)
+
+    const textarea = screen.getByRole('textbox', {
+      name: 'Mensagem para o lead',
+    }) as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'olá manual' } })
+    expect(textarea.value).toBe('olá manual')
+
+    fireEvent.click(screen.getByRole('button', { name: /Enviar/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+      expect(url).toMatch(/\/api\/conversations\/conv-1\/messages$/)
+    })
+    await waitFor(() => expect(textarea.value).toBe(''))
+  })
+})

--- a/frontend/src/components/chat/ManualMessageInput.tsx
+++ b/frontend/src/components/chat/ManualMessageInput.tsx
@@ -1,0 +1,76 @@
+/**
+ * Input de envio manual: humano responde via UI quando bot está pausado.
+ *
+ * Renderizado SÓ quando `lead.bot_paused = true` (escondido com bot ativo
+ * pra não confundir — não dá pra ter humano e bot respondendo ao mesmo
+ * tempo). Backend persiste como Message OUT, dispara Evolution send_text,
+ * emite `wa.message.sent` no Socket.IO. SocketProvider mescla no cache,
+ * UI atualiza automaticamente — sem optimistic update aqui.
+ */
+
+import { Send } from 'lucide-react'
+import { type FormEvent, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { useSendManualMessage } from '@/hooks/useSendManualMessage'
+
+interface Props {
+  conversationId: string
+}
+
+const MAX_LENGTH = 4096 // limite WhatsApp (também validado no backend)
+
+export function ManualMessageInput({ conversationId }: Props) {
+  const [text, setText] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const sendMutation = useSendManualMessage()
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const trimmed = text.trim()
+    if (!trimmed) return
+    setError(null)
+    sendMutation.mutate(
+      { conversationId, content: trimmed },
+      {
+        onSuccess: () => setText(''),
+        onError: (err) => setError((err as Error).message),
+      }
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="border-status-needs-human/30 bg-status-needs-human/5 flex items-end gap-2 border-t p-3"
+      aria-label="Envio manual (humano)"
+    >
+      <div className="flex-1">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value.slice(0, MAX_LENGTH))}
+          placeholder="Responda como humano… (bot está pausado)"
+          rows={2}
+          maxLength={MAX_LENGTH}
+          disabled={sendMutation.isPending}
+          className="bg-background border-input text-foreground focus-visible:outline-ring/60 w-full resize-none rounded-md border px-3 py-2 text-sm focus-visible:outline-2 disabled:opacity-60"
+          aria-label="Mensagem para o lead"
+        />
+        {error && (
+          <p role="alert" className="text-destructive mt-1 text-xs">
+            {error}
+          </p>
+        )}
+      </div>
+      <Button
+        type="submit"
+        size="sm"
+        disabled={sendMutation.isPending || text.trim().length === 0}
+        aria-label="Enviar mensagem como humano"
+      >
+        <Send className="mr-1 size-4" />
+        {sendMutation.isPending ? 'Enviando…' : 'Enviar'}
+      </Button>
+    </form>
+  )
+}

--- a/frontend/src/components/lead/LeadPanel.test.tsx
+++ b/frontend/src/components/lead/LeadPanel.test.tsx
@@ -16,6 +16,7 @@ const lead: Lead = {
   lead_goal: 'aumentar conversão',
   estimated_volume: '10k leads/mês',
   status: 'qualified',
+  bot_paused: false,
   created_at: '2026-04-25T14:00:00Z',
   updated_at: '2026-04-25T15:00:00Z',
 }

--- a/frontend/src/hooks/CLAUDE.md
+++ b/frontend/src/hooks/CLAUDE.md
@@ -20,6 +20,8 @@
 | `useLead(id?)` | Detalhe completo do Lead via REST. SocketProvider atualiza via `lead.updated`. |
 | `useWhatsAppConnection()` | Estado da conexão WhatsApp via REST (`/api/whatsapp/connection`) com polling backup de 60s. SocketProvider faz `setQueryData` quando chega `wa.connection.update` para resposta imediata. |
 | `useConnectionStatus()` | Merge: `state` vem do `useWhatsAppConnection()` query (REST + socket), `qrcode` vem do `useSocketContext()` (evento puro). Retorna `{state, qrcode, isLoading}`. |
+| `useResumeBot()` | Mutation `POST /api/leads/{id}/resume-bot`. Em sucesso atualiza `leadKeys.detail(id)` no cache + invalida lista. Usado pelo botão "Retomar bot" no `ConversationHeader`. |
+| `useSendManualMessage()` | Mutation `POST /api/conversations/{id}/messages`. Sem optimistic update — Socket.IO `wa.message.sent` mescla a Message OUT no cache. Usado pelo `ManualMessageInput` quando bot está pausado. |
 
 ## Não fazer
 

--- a/frontend/src/hooks/useConversationsQuery.test.tsx
+++ b/frontend/src/hooks/useConversationsQuery.test.tsx
@@ -22,6 +22,7 @@ const sample: ConversationListResponse = {
         phone: '+5511999990001',
         service_interest: 'unknown',
         status: 'new',
+        bot_paused: false,
       },
       last_intent: null,
       last_message_at: '2026-04-25T15:00:00Z',

--- a/frontend/src/hooks/useLead.test.tsx
+++ b/frontend/src/hooks/useLead.test.tsx
@@ -16,6 +16,7 @@ const sample: Lead = {
   lead_goal: null,
   estimated_volume: null,
   status: 'qualified',
+  bot_paused: false,
   created_at: '2026-04-25T14:00:00Z',
   updated_at: '2026-04-25T15:00:00Z',
 }

--- a/frontend/src/hooks/useResumeBot.test.tsx
+++ b/frontend/src/hooks/useResumeBot.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { conversationKeys, leadKeys } from '@/lib/queryKeys'
+import { AllProviders, makeTestQueryClient } from '@/test/test-utils'
+import type { Lead } from '@/types/domain'
+
+import { useResumeBot } from './useResumeBot'
+
+const responseLead: Lead = {
+  id: 'lead-1',
+  whatsapp_jid: '5511999990001@s.whatsapp.net',
+  name: 'Cliente',
+  company: null,
+  phone: '+5511999990001',
+  service_interest: 'contact_z',
+  lead_goal: null,
+  estimated_volume: null,
+  status: 'qualified',
+  bot_paused: false,
+  created_at: '2026-04-25T14:00:00Z',
+  updated_at: '2026-04-25T15:30:00Z',
+}
+
+describe('useResumeBot', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(responseLead), { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('chama POST /api/leads/{id}/resume-bot e atualiza cache do lead', async () => {
+    const client = makeTestQueryClient()
+    // Pré-cache do lead pausado pra confirmar que o sucesso atualiza
+    client.setQueryData(leadKeys.detail('lead-1'), { ...responseLead, bot_paused: true })
+
+    const { result } = renderHook(() => useResumeBot(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    result.current.mutate('lead-1')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    const calledInit = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+    expect(calledUrl).toMatch(/\/api\/leads\/lead-1\/resume-bot$/)
+    expect(calledInit.method).toBe('POST')
+
+    expect(client.getQueryData(leadKeys.detail('lead-1'))).toEqual(responseLead)
+  })
+
+  it('invalida lista de conversas no sucesso', async () => {
+    const client = makeTestQueryClient()
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries')
+
+    const { result } = renderHook(() => useResumeBot(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    result.current.mutate('lead-1')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: conversationKeys.lists() })
+  })
+})

--- a/frontend/src/hooks/useResumeBot.ts
+++ b/frontend/src/hooks/useResumeBot.ts
@@ -1,0 +1,23 @@
+/**
+ * Mutation: libera o bot de um lead pausado por handoff humano.
+ *
+ * Backend `POST /api/leads/{id}/resume-bot` é idempotente. Em sucesso,
+ * invalida `leadKeys.detail(id)` + `conversationKeys.lists()` (lista
+ * mostra indicador de pausa, precisa atualizar).
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { resumeBot } from '@/lib/api'
+import { conversationKeys, leadKeys } from '@/lib/queryKeys'
+
+export function useResumeBot() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (leadId: string) => resumeBot(leadId),
+    onSuccess: (lead) => {
+      queryClient.setQueryData(leadKeys.detail(lead.id), lead)
+      queryClient.invalidateQueries({ queryKey: conversationKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/hooks/useSendManualMessage.test.tsx
+++ b/frontend/src/hooks/useSendManualMessage.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AllProviders, makeTestQueryClient } from '@/test/test-utils'
+import type { Message } from '@/types/domain'
+
+import { useSendManualMessage } from './useSendManualMessage'
+
+const responseMessage: Message = {
+  id: 'msg-out-1',
+  conversation_id: 'conv-1',
+  whatsapp_message_id: 'WA-123',
+  direction: 'out',
+  type: 'text',
+  content: 'oi humano',
+  transcription: null,
+  media_url: null,
+  media_mime: null,
+  intent: null,
+  status: 'sent',
+  quoted_message_id: null,
+  error_reason: null,
+  created_at: '2026-04-25T15:30:00Z',
+}
+
+describe('useSendManualMessage', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(responseMessage), { status: 201 }))
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('chama POST /api/conversations/{id}/messages com body correto', async () => {
+    const client = makeTestQueryClient()
+    const { result } = renderHook(() => useSendManualMessage(), {
+      wrapper: ({ children }) => <AllProviders client={client}>{children}</AllProviders>,
+    })
+    result.current.mutate({ conversationId: 'conv-1', content: 'oi humano' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    const calledInit = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+    expect(calledUrl).toMatch(/\/api\/conversations\/conv-1\/messages$/)
+    expect(calledInit.method).toBe('POST')
+    expect(JSON.parse(calledInit.body as string)).toEqual({ content: 'oi humano' })
+    expect(result.current.data).toEqual(responseMessage)
+  })
+})

--- a/frontend/src/hooks/useSendManualMessage.ts
+++ b/frontend/src/hooks/useSendManualMessage.ts
@@ -1,0 +1,23 @@
+/**
+ * Mutation: humano envia mensagem manual via UI.
+ *
+ * `POST /api/conversations/{id}/messages` no backend persiste Message OUT
+ * + chama Evolution send_text + emite `wa.message.sent` no Socket.IO.
+ * O SocketProvider já mescla esse evento no cache de mensagens, então
+ * esse hook só precisa disparar a mutation — UI atualiza automaticamente
+ * via Socket.IO.
+ *
+ * Não fazemos optimistic update aqui porque o backend valida o conteúdo
+ * e o WhatsApp pode falhar; mostrar a mensagem antes da confirmação
+ * causaria flicker. Spinner no botão durante isLoading é suficiente.
+ */
+
+import { useMutation } from '@tanstack/react-query'
+
+import { sendManualMessage, type ManualMessageInput } from '@/lib/api'
+
+export function useSendManualMessage() {
+  return useMutation({
+    mutationFn: (input: ManualMessageInput) => sendManualMessage(input),
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   ConversationDetail,
   ConversationListResponse,
   Lead,
+  Message,
   MessagePageResponse,
   WhatsAppConnectionResponse,
 } from '@/types/domain'
@@ -87,6 +88,24 @@ export async function fetchMessages(
 
 export async function fetchLead(id: string): Promise<Lead> {
   return api<Lead>(`/api/leads/${id}`)
+}
+
+export async function resumeBot(leadId: string): Promise<Lead> {
+  return api<Lead>(`/api/leads/${leadId}/resume-bot`, { method: 'POST' })
+}
+
+export interface ManualMessageInput {
+  conversationId: string
+  content: string
+}
+
+export async function sendManualMessage(
+  input: ManualMessageInput
+): Promise<Message> {
+  return api<Message>(`/api/conversations/${input.conversationId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({ content: input.content }),
+  })
 }
 
 /** Estado da conexão WhatsApp via backend proxy → Evolution.

--- a/frontend/src/providers/SocketProvider.test.tsx
+++ b/frontend/src/providers/SocketProvider.test.tsx
@@ -171,6 +171,7 @@ describe('SocketProvider', () => {
       lead_goal: null,
       estimated_volume: null,
       status: 'qualified',
+      bot_paused: false,
       created_at: '2026-04-25T14:00:00Z',
       updated_at: '2026-04-25T15:30:00Z',
     }
@@ -195,6 +196,7 @@ describe('SocketProvider', () => {
             phone: null,
             service_interest: 'unknown',
             status: 'new',
+            bot_paused: false,
           },
           last_intent: null,
           last_message_at: '2026-04-25T15:00:00Z',
@@ -218,6 +220,7 @@ describe('SocketProvider', () => {
       lead_goal: null,
       estimated_volume: null,
       status: 'qualified',
+      bot_paused: false,
       created_at: '2026-04-25T14:00:00Z',
       updated_at: '2026-04-25T15:30:00Z',
     }

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -1,17 +1,17 @@
 /**
- * `ConversationView` — painel central com mensagens. Usado pela rota
- * /conversations/:id, que pode também renderizar lead/QR do lado.
- *
- * Aceita slots opcionais para botão "voltar" (mobile) e ações no header
- * (LeadSheet em mobile/tablet).
+ * `ConversationView` — painel central com mensagens + header inteligente
+ * (badge PAUSADO + botão Retomar quando lead.bot_paused) + input manual
+ * embaixo da lista quando bot pausado.
  */
 
 import type { ReactNode } from 'react'
 
+import { ConversationHeader } from '@/components/chat/ConversationHeader'
+import { ManualMessageInput } from '@/components/chat/ManualMessageInput'
 import { MessageList } from '@/components/chat/MessageList'
 import { LeadSheet } from '@/components/lead/LeadSheet'
 import { MessageListSkeleton } from '@/components/Skeletons'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { useConversationMessages } from '@/hooks/useConversationMessages'
 import { useLead } from '@/hooks/useLead'
 import { useSocketContext } from '@/providers/socket-context'
@@ -36,34 +36,39 @@ export function ConversationView({
   const messages = useConversationMessages(conversationId)
   const listEntry = listItems.find((it) => it.conversation.id === conversationId)
   const leadQuery = useLead(leadId)
+  const lead = leadQuery.data ?? null
 
   const headerLabel =
     listEntry?.lead.name || listEntry?.lead.whatsapp_jid?.replace(/@.*/, '') || 'Conversa'
 
   return (
     <Card className="flex flex-1 flex-col overflow-hidden p-0">
-      <CardHeader className="flex flex-row items-center justify-between border-b py-2.5">
-        <div className="flex items-center gap-2 min-w-0">
-          {mobileBackButton}
-          <CardTitle className="truncate text-sm">{headerLabel}</CardTitle>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 lg:hidden">
-          <LeadSheet lead={leadQuery.data ?? null} />
-        </div>
-      </CardHeader>
-      <CardContent className="flex-1 overflow-hidden p-0">
-        {messages.isLoading ? (
-          <MessageListSkeleton />
-        ) : messages.error ? (
-          <div role="alert" className="text-destructive p-4 text-xs">
-            Erro ao carregar mensagens. {(messages.error as Error).message}
+      <ConversationHeader
+        title={headerLabel}
+        lead={lead}
+        mobileBackButton={mobileBackButton}
+        rightSlot={
+          <div className="lg:hidden">
+            <LeadSheet lead={lead} />
           </div>
-        ) : (
-          <MessageList
-            messages={messages.data?.items ?? []}
-            thinking={thinking[conversationId] === true}
-          />
-        )}
+        }
+      />
+      <CardContent className="flex flex-1 flex-col overflow-hidden p-0">
+        <div className="flex-1 overflow-hidden">
+          {messages.isLoading ? (
+            <MessageListSkeleton />
+          ) : messages.error ? (
+            <div role="alert" className="text-destructive p-4 text-xs">
+              Erro ao carregar mensagens. {(messages.error as Error).message}
+            </div>
+          ) : (
+            <MessageList
+              messages={messages.data?.items ?? []}
+              thinking={thinking[conversationId] === true}
+            />
+          )}
+        </div>
+        {lead?.bot_paused && <ManualMessageInput conversationId={conversationId} />}
       </CardContent>
     </Card>
   )

--- a/frontend/src/routes/conversations.tsx
+++ b/frontend/src/routes/conversations.tsx
@@ -46,6 +46,7 @@ function adaptListItem(items: ReturnType<typeof useConversationsQuery>['data']) 
       lead_goal: null,
       estimated_volume: null,
       status: it.lead.status,
+      bot_paused: it.lead.bot_paused,
       created_at: it.created_at,
       updated_at: it.last_message_at,
     },

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -42,6 +42,7 @@ export interface Lead {
   lead_goal: string | null
   estimated_volume: string | null
   status: LeadStatus
+  bot_paused: boolean
   created_at: string
   updated_at: string
 }
@@ -82,6 +83,7 @@ export interface LeadSummary {
   phone: string | null
   service_interest: ServiceInterest
   status: LeadStatus
+  bot_paused: boolean
 }
 
 export interface ConversationListItem {


### PR DESCRIPTION
Closes #68. ConversationHeader com badge PAUSADO + botão Retomar; ManualMessageInput abaixo das mensagens quando paused; ConversationList marca conversas pausadas. 4 testes novos (58 total). Coverage 85.8% / 68.3% / 87.4% / 91.3%. Reviews vercel:react-best-practices + sentry-skills:code-review.