### PR TITLE
fix(env): comentário inline no .env.example vira valor de OPENAI_API_KEY no docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,23 @@
 # ============================================================================
-# Setup mínimo: edite SÓ as 4 chaves abaixo. O resto já tem default funcional
-# pro Docker Compose. NUNCA committar este arquivo com valores reais — o
-# .env (gitignored) é onde os secrets ficam.
+# Setup mínimo para o recrutador: edite SÓ as 4 chaves OBRIGATÓRIAS abaixo.
+# O resto já tem default funcional pro Docker Compose.
+#
+# IMPORTANTE: NÃO use comentários inline (na MESMA linha de `=`) quando o
+# valor é vazio. O parser do docker-compose --env-file confunde o comentário
+# com o valor. Sempre coloque o comentário na LINHA DE CIMA.
+# NUNCA committar este arquivo com valores reais — o .env (gitignored) é
+# onde os secrets ficam.
 # ============================================================================
 
 # ---- 1) IA (escolha 1 dos 2 providers) ----
-AI_PROVIDER=openai                       # openai | anthropic
-OPENAI_API_KEY=                          # OBRIGATÓRIO se AI_PROVIDER=openai (também usado por STT/TTS/vision)
-ANTHROPIC_API_KEY=                       # OBRIGATÓRIO se AI_PROVIDER=anthropic
+# openai | anthropic
+AI_PROVIDER=openai
+
+# OBRIGATÓRIO se AI_PROVIDER=openai (também usado por STT/TTS/vision por fallback)
+OPENAI_API_KEY=
+
+# OBRIGATÓRIO se AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=
 
 # ---- 2) WhatsApp (Evolution) — sua "senha" da instância ----
 EVOLUTION_API_KEY=change-me-on-first-run
@@ -21,8 +31,8 @@ VITE_ADMIN_TOKEN=change-me-admin-token
 # override sem editar docker-compose.yml).
 # ============================================================================
 
-# AI / IA
-AI_MODEL=gpt-4o-mini                     # ou claude-sonnet-4-6 quando AI_PROVIDER=anthropic
+# AI / IA — modelo padrão (use claude-sonnet-4-6 quando AI_PROVIDER=anthropic)
+AI_MODEL=gpt-4o-mini
 
 # Database (asyncpg). Backend precisa explícito; o EVOLUTION_DATABASE_URI vai
 # pra container Evolution e usa schema separado no MESMO Postgres.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,17 +102,17 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       AI_PROVIDER: ${AI_PROVIDER:-openai}
       AI_MODEL: ${AI_MODEL:-gpt-4o-mini}
-      AI_API_KEY: ${AI_API_KEY}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      AI_API_KEY: ${AI_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       STT_PROVIDER: ${STT_PROVIDER:-openai}
       STT_MODEL: ${STT_MODEL:-whisper-1}
-      STT_API_KEY: ${STT_API_KEY}
+      STT_API_KEY: ${STT_API_KEY:-}
       TTS_PROVIDER: ${TTS_PROVIDER:-openai}
       TTS_MODEL: ${TTS_MODEL:-gpt-4o-mini-tts}
       TTS_VOICE: ${TTS_VOICE:-alloy}
       TTS_FORMAT: ${TTS_FORMAT:-opus}
-      TTS_API_KEY: ${TTS_API_KEY}
+      TTS_API_KEY: ${TTS_API_KEY:-}
       VISION_ENABLED: ${VISION_ENABLED:-true}
       VISION_MODEL: ${VISION_MODEL:-gpt-4o-mini}
       DATABASE_URL: ${DATABASE_URL}


### PR DESCRIPTION
## Bug crítico para a entrega

O parser de \`docker compose --env-file\` interpreta o comentário inline como valor quando a variável tem valor vazio.

### Antes
\`\`\`bash
$ cp .env.example .env
$ docker compose config | grep API_KEY
OPENAI_API_KEY: '# OBRIGATÓRIO se AI_PROVIDER=openai (também usado por STT/TTS/vision)'
ANTHROPIC_API_KEY: '# OBRIGATÓRIO se AI_PROVIDER=anthropic'
\`\`\`

Recrutador que clona o repo, copia .env.example pra .env e edita só algumas chaves teria a string \`# OBRIGATÓRIO ...\` enviada como Bearer token pra OpenAI/Anthropic — 401 instantâneo na primeira mensagem.

Bug introduzido no PR #67 quando o setup foi simplificado.

Adicionalmente, três warnings cosméticos apareciam:
\`\`\`
WARN[0000] The "AI_API_KEY" variable is not set. Defaulting to a blank string.
WARN[0000] The "STT_API_KEY" variable is not set. Defaulting to a blank string.
WARN[0000] The "TTS_API_KEY" variable is not set. Defaulting to a blank string.
\`\`\`

## Fix

1. \`.env.example\`: TODOS os comentários movidos pra linha de cima (nunca inline com \`=\` vazio). Header do arquivo agora documenta o gotcha explicitamente.
2. \`docker-compose.yml\`: \`AI_API_KEY\`, \`OPENAI_API_KEY\`, \`ANTHROPIC_API_KEY\`, \`STT_API_KEY\`, \`TTS_API_KEY\` ganham \`:-\` default vazio para silenciar warnings cosméticos. **Segurança preservada** — não tem credencial hardcoded no compose; valores reais ainda vêm do \`.env\` do recrutador.

### Depois
\`\`\`bash
$ cp .env.example .env
$ docker compose config 2>&1 | grep -i warn
(zero warnings)

$ docker compose config | grep -E "OPENAI_API_KEY|ANTHROPIC_API_KEY|AI_API_KEY"
AI_API_KEY: ""
ANTHROPIC_API_KEY: ""
OPENAI_API_KEY: ""
\`\`\`

## Smoke local

\`\`\`bash
cp .env.example /tmp/recruiter.env
docker compose --env-file /tmp/recruiter.env config 2>&1 | grep -i warn
# (sem output — zero warnings)

docker compose --env-file /tmp/recruiter.env config | grep -E "OPENAI_API_KEY|ANTHROPIC_API_KEY|STT_API_KEY|TTS_API_KEY|AI_API_KEY"
# AI_API_KEY: ""
# ANTHROPIC_API_KEY: ""
# OPENAI_API_KEY: ""
# STT_API_KEY: ""
# TTS_API_KEY: ""
\`\`\`

## Test plan

- [x] \`docker compose --env-file .env.example config\` zero warnings
- [x] valores vazios continuam vazios (não pegam mais o comentário)
- [x] vars com valor (EVOLUTION_API_KEY, ADMIN_API_TOKEN) preservadas
- [x] sem credencial hardcoded no compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)